### PR TITLE
Return non-zero value from test scripts if there are failed tests.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2013-01-18  Anton Kolesov <akolesov@synopsys.com>
+
+	* run-tests.sh, run-elf32-tests.sh, run-uclibc-tests.sh, arc-init
+	(run_check): Return non-zero value from scripts if there are failed tests.
+
 2013-01-11  Jeremy Bennett <jeremy.bennett@embecosm.com>
 
 	* arc-init.sh (run_check): Don't fail overall if make fails.

--- a/arc-init.sh
+++ b/arc-init.sh
@@ -78,6 +78,7 @@
 # -----------------------------------------------------------------------------
 # Useful functions
 # Function to run a particular test in a particular directory
+# Returns non-zero value if make fails.
 
 # $1 - build directory
 # $2 - tool to test (e.g. "binutils" will run "check-binutils"
@@ -91,9 +92,11 @@ function run_check {
     echo "=======================" >> "${logfile}"
 
     cd ${bd}
-    make ${PARALLEL} "check-${tool}" >>  "${logfile}" 2>&1 || true
+    test_result=0
+    make ${PARALLEL} "check-${tool}" >>  "${logfile}" 2>&1 || test_result=1
     echo
     cd - > /dev/null 2>&1
+    return ${test_result}
 }
 
 # Save the results files to the results directory, removing spare line feed

--- a/run-elf32-tests.sh
+++ b/run-elf32-tests.sh
@@ -62,29 +62,36 @@ res_elf="$(echo "${ARC_GNU}")/results/elf32-results-$(date -u +%F-%H%M)"
 mkdir ${res_elf}
 
 # Run the tests
-run_check ${bd_elf}     binutils            "${logfile_elf}"
-save_res  ${bd_elf}     ${res_elf} binutils/binutils     "${logfile_elf}"
-run_check ${bd_elf}     gas                 "${logfile_elf}"
-save_res  ${bd_elf}     ${res_elf} gas/testsuite/gas     "${logfile_elf}"
-run_check ${bd_elf}     ld                  "${logfile_elf}"
-save_res  ${bd_elf}     ${res_elf} ld/ld                 "${logfile_elf}"
-run_check ${bd_elf}     gcc                 "${logfile_elf}"
-save_res  ${bd_elf}     ${res_elf} gcc/testsuite/gcc/gcc "${logfile_elf}"
+status=0
+run_check ${bd_elf}     binutils            "${logfile_elf}" || status=1
+save_res  ${bd_elf}     ${res_elf} binutils/binutils     "${logfile_elf}" \
+    || status=1
+run_check ${bd_elf}     gas                 "${logfile_elf}" || status=1
+save_res  ${bd_elf}     ${res_elf} gas/testsuite/gas     "${logfile_elf}" \
+    || status=1
+run_check ${bd_elf}     ld                  "${logfile_elf}" || status=1
+save_res  ${bd_elf}     ${res_elf} ld/ld                 "${logfile_elf}" \
+    || status=1
+run_check ${bd_elf}     gcc                 "${logfile_elf}" || status=1
+save_res  ${bd_elf}     ${res_elf} gcc/testsuite/gcc/gcc "${logfile_elf}" \
+    || status=1
 echo "Testing g++..."
-save_res  ${bd_elf}     ${res_elf} gcc/testsuite/g++/g++ "${logfile_elf}"
+save_res  ${bd_elf}     ${res_elf} gcc/testsuite/g++/g++ "${logfile_elf}" \
+    || status=1
 # libgcc and libgloss tests are currently empty, so nothing to run or save.
 # run_check ${bd_elf}     target-libgcc       "${logfile_elf}"
 # run_check ${bd_elf}     target-libgloss     "${logfile_elf}"
-run_check ${bd_elf}     target-newlib       "${logfile_elf}"
+run_check ${bd_elf}     target-newlib       "${logfile_elf}" || status=1
 save_res  ${bd_elf}     ${res_elf} arc-elf32/newlib/testsuite/newlib \
-    "${logfile_elf}"
-run_check ${bd_elf}     target-libstdc++-v3 "${logfile_elf}"
+    "${logfile_elf}" || status=1
+run_check ${bd_elf}     target-libstdc++-v3 "${logfile_elf}" || status=1
 save_res  ${bd_elf}     ${res_elf} arc-elf32/libstdc++-v3/testsuite/libstdc++ \
-    "${logfile_elf}"
-run_check ${bd_elf_gdb} sim                 "${logfile_elf}"
-save_res  ${bd_elf_gdb} ${res_elf} sim/testsuite/sim     "${logfile_elf}"
-run_check ${bd_elf_gdb} gdb                 "${logfile_elf}"
-save_res  ${bd_elf_gdb} ${res_elf} gdb/testsuite/gdb     "${logfile_elf}"
+    "${logfile_elf}" || status=1
+run_check ${bd_elf_gdb} sim                 "${logfile_elf}" || status=1
+save_res  ${bd_elf_gdb} ${res_elf} sim/testsuite/sim     "${logfile_elf}" \
+    || status=1
+run_check ${bd_elf_gdb} gdb                 "${logfile_elf}" || status=1
+save_res  ${bd_elf_gdb} ${res_elf} gdb/testsuite/gdb     "${logfile_elf}" \
+    || status=1
 
-# Success
-exit 0
+exit ${status}

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -44,6 +44,9 @@
 
 #     If specified, run the arc-uclibc-linux- tests (default is --uclibc).
 
+# This script exits with zero if every test has passed and with non-zero value
+# otherwise.
+
 # ------------------------------------------------------------------------------
 # Set default values for some options
 elf32="--elf32"
@@ -96,12 +99,15 @@ mkdir -p ${ARC_GNU}/results
 # Export everything needed by sub-scripts
 export ARC_GNU
 
+status=0
+
 # Run the ELF32 tests
 if [ "${elf32}" = "--elf32" ]
 then
     if ! "${ARC_GNU}"/toolchain/run-elf32-tests.sh
     then
-	echo "ERROR: arc-elf32- tests failed to run."
+        echo "ERROR: arc-elf32- tests failed to run."
+        status=1
     fi
 fi
 
@@ -110,6 +116,10 @@ if [ "${uclibc}" = "--uclibc" ]
 then
     if ! "${ARC_GNU}"/toolchain/run-uclibc-tests.sh
     then
-	echo "ERROR: arc-linux-uclibc- tests failed to run."
+        echo "ERROR: arc-linux-uclibc- tests failed to run."
+        status=1
     fi
 fi
+
+exit ${status}
+

--- a/run-uclibc-tests.sh
+++ b/run-uclibc-tests.sh
@@ -61,23 +61,31 @@ rm -f "${logfile_linux}"
 res_linux="$(echo "${ARC_GNU}")/results/linux-results-$(date -u +%F-%H%M)"
 mkdir ${res_linux}
 
-run_check ${bd_linux}     binutils            "${logfile_linux}"
-save_res  ${bd_linux}     ${res_linux} binutils/binutils     "${logfile_linux}"
-run_check ${bd_linux}     gas                 "${logfile_linux}"
-save_res  ${bd_linux}     ${res_linux} gas/testsuite/gas     "${logfile_linux}"
-run_check ${bd_linux}     ld                  "${logfile_linux}"
-save_res  ${bd_linux}     ${res_linux} ld/ld                 "${logfile_linux}"
-run_check ${bd_linux}     gcc                 "${logfile_linux}"
-save_res  ${bd_linux}     ${res_linux} gcc/testsuite/gcc/gcc "${logfile_linux}"
+# Run tests
+status=0
+run_check ${bd_linux}     binutils            "${logfile_linux}" || status=1
+save_res  ${bd_linux}     ${res_linux} binutils/binutils     "${logfile_linux}" \
+    || status=1
+run_check ${bd_linux}     gas                 "${logfile_linux}" || status=1
+save_res  ${bd_linux}     ${res_linux} gas/testsuite/gas     "${logfile_linux}" \
+    || status=1
+run_check ${bd_linux}     ld                  "${logfile_linux}" || status=1
+save_res  ${bd_linux}     ${res_linux} ld/ld                 "${logfile_linux}" \
+    || status=1
+run_check ${bd_linux}     gcc                 "${logfile_linux}" || status=1
+save_res  ${bd_linux}     ${res_linux} gcc/testsuite/gcc/gcc "${logfile_linux}" \
+    || status=1
 echo "Testing g++..."
-save_res  ${bd_linux}     ${res_linux} gcc/testsuite/g++/g++ "${logfile_linux}"
+save_res  ${bd_linux}     ${res_linux} gcc/testsuite/g++/g++ "${logfile_linux}" \
+    || status=1
 # libgcc tests are currently empty, so nothing to run or save.
 # run_check ${bd_linux}     target-libgcc       "${logfile_linux}"
-run_check ${bd_linux}     target-libstdc++-v3 "${logfile_linux}"
+run_check ${bd_linux}     target-libstdc++-v3 "${logfile_linux}" || status=1
 save_res  ${bd_linux}     ${res_linux} \
-    arc-linux-uclibc/libstdc++-v3/testsuite/libstdc++ "${logfile_linux}"
-run_check ${bd_linux_gdb} gdb                 "${logfile_linux}"
-save_res  ${bd_linux_gdb} ${res_linux} gdb/testsuite/gdb     "${logfile_linux}"
+    arc-linux-uclibc/libstdc++-v3/testsuite/libstdc++ "${logfile_linux}" \
+    || status=1
+run_check ${bd_linux_gdb} gdb                 "${logfile_linux}" || status=1
+save_res  ${bd_linux_gdb} ${res_linux} gdb/testsuite/gdb     "${logfile_linux}" \
+    || status=1
 
-# Success
-exit 0
+exit ${status}


### PR DESCRIPTION
2013-01-18  Anton Kolesov akolesov@synopsys.com

```
* run-tests.sh, run-elf32-tests.sh, run-uclibc-tests.sh, arc-init
(run_check): Return non-zero value from scripts if there are failed tests.
```
