### PR TITLE
Uclibc tests bigendian

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 2013-01-18  Anton Kolesov <akolesov@synopsys.com>
 
+	* run-tests.sh. run-uclibc-tests.sh: Handle tests for big endian properly.
+
+2013-01-18  Anton Kolesov <akolesov@synopsys.com>
+
 	* run-tests.sh, run-elf32-tests.sh, run-uclibc-tests.sh, arc-init
 	(run_check): Return non-zero value from scripts if there are failed tests.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 2013-01-18  Anton Kolesov <akolesov@synopsys.com>
 
+	* arc-init.sh (save_res): use "tr" instead of "dos2unix" to replace
+	Windows' line endings with Linux' line endings.
+
+2013-01-18  Anton Kolesov <akolesov@synopsys.com>
+
 	* run-tests.sh. run-uclibc-tests.sh: Handle tests for big endian properly.
 
 2013-01-18  Anton Kolesov <akolesov@synopsys.com>

--- a/arc-init.sh
+++ b/arc-init.sh
@@ -113,13 +113,14 @@ function save_res {
     logfile=$4
     resbase=`basename $resfile`
 
-    # Use -f, since funny line endings can cause dos2unix to think these are
-    # binary files.
-    dos2unix -f --newfile ${bd}/${resfile}.log \
-	                  ${rd}/${resbase}.log >> ${logfile} 2>&1
+    # Generated files have Windows line endings. dos2unix tool cannot be used
+    # because sometimes it recognizes input files as binary and refuses to
+    # work. Specifying option "-f" could solve this problem, but RedHats
+    # dos2unix is too old to understand this option. "tr -d '\015\" seems to be
+    # more universal solution.
+    tr -d '\015' < ${bd}/${resfile}.log > ${rd}/${resbase}.log 2> ${logfile}
     chmod ugo-wx ${rd}/${resbase}.log
-    dos2unix -f --newfile ${bd}/${resfile}.sum \
-                          ${rd}/${resbase}.sum >> ${logfile} 2>&1
+    tr -d '\015' < ${bd}/${resfile}.sum > ${rd}/${resbase}.sum 2> ${logfile}
     chmod ugo-wx ${rd}/${resbase}.sum
 
     # Report the summary to the user

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -44,6 +44,12 @@
 
 #     If specified, run the arc-uclibc-linux- tests (default is --uclibc).
 
+# --big-endian
+
+#     If specified, test the big-endian version of the tool chains
+#     (i.e. arceb-elf32- and arceb-linux-uclibc-). At present this is only
+#     implemented for the Linux tool chain.
+
 # This script exits with zero if every test has passed and with non-zero value
 # otherwise.
 
@@ -69,10 +75,14 @@ case ${opt} in
 	uclibc=$1
 	;;
 
+    --big-endian)
+        ARC_ENDIAN=big
+        ;;
     ?*)
 	echo "Usage: ./run-tests.sh [--source-dir <source_dir>]"
         echo "                      [--elf32 | --no-elf32]"
         echo "                      [--uclibc | --no-uclibc]"
+        echo "                      [--big-endian]"
 	exit 1
 	;;
 
@@ -92,12 +102,19 @@ then
     ARC_GNU=`(cd "$d/.." && pwd)`
 fi
 
+# Little endian is default
+if [ "x${ARC_ENDIAN}" = "x" ]
+then
+    ARC_ENDIAN=little
+fi
+
 # Set up logfile and results directories if either does not exist
 mkdir -p ${ARC_GNU}/logs
 mkdir -p ${ARC_GNU}/results
 
 # Export everything needed by sub-scripts
 export ARC_GNU
+export ARC_ENDIAN
 
 status=0
 

--- a/run-uclibc-tests.sh
+++ b/run-uclibc-tests.sh
@@ -35,6 +35,9 @@
 
 #   ${ARC_GNU}/results must exist and be writable
 
+#   ARC_ENDIAN environment variable must be either "big" or "little" to
+#   identify which type of toolchain tool chain to test.
+
 # Result is 0 if successful, 1 otherwise.
 
 
@@ -61,6 +64,14 @@ rm -f "${logfile_linux}"
 res_linux="$(echo "${ARC_GNU}")/results/linux-results-$(date -u +%F-%H%M)"
 mkdir ${res_linux}
 
+# Location of some files depends on endiannes
+if [ "${ARC_ENDIAN}" = "little" ]
+then
+    arc_linux_directory=arc-linux-uclibc
+else
+    arc_linux_directory=arceb-linux-uclibc
+fi
+
 # Run tests
 status=0
 run_check ${bd_linux}     binutils            "${logfile_linux}" || status=1
@@ -82,7 +93,7 @@ save_res  ${bd_linux}     ${res_linux} gcc/testsuite/g++/g++ "${logfile_linux}" 
 # run_check ${bd_linux}     target-libgcc       "${logfile_linux}"
 run_check ${bd_linux}     target-libstdc++-v3 "${logfile_linux}" || status=1
 save_res  ${bd_linux}     ${res_linux} \
-    arc-linux-uclibc/libstdc++-v3/testsuite/libstdc++ "${logfile_linux}" \
+    ${arc_linux_directory}/libstdc++-v3/testsuite/libstdc++ "${logfile_linux}" \
     || status=1
 run_check ${bd_linux_gdb} gdb                 "${logfile_linux}" || status=1
 save_res  ${bd_linux_gdb} ${res_linux} gdb/testsuite/gdb     "${logfile_linux}" \


### PR DESCRIPTION
2013-01-18  Anton Kolesov akolesov@synopsys.com

```
* arc-init.sh (save_res): use "tr" instead of "dos2unix" to replace
Windows' line endings with Linux' line endings.
```

2013-01-18  Anton Kolesov akolesov@synopsys.com

```
* run-tests.sh. run-uclibc-tests.sh: Handle tests for big endian properly.
```
