### PR TITLE
Test script for ELF32 was still trying to cd into bd-elf32-gdb, which do...

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2013-03-26	Anton Kolesov <anton.kolesov@synopsys.com>
+
+	* build-uclibc.sh: Fix error with uClibc distclean which caused build
+	process to fail.
+
 2013-03-26  Jeremy Bennett <jeremy.bennett@embecosm.com>
 
 	* run-elf32-tests.sh: Replace bd_elf_gdb with bd_elf throughout.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2013-03-22	Anton Kolesov <anton.kolesov@synopsys.com>
+
+	* run-elf32-tests.sh: Fix invalid reference to GDB build directory. GDB
+	used to be built in separate directory but test script was still trying to
+	use the old directory.
+
 2013-03-18  Jeremy Bennett <jeremy.bennett@embecosm.com>
 
 	* build-all.sh: Add --big-endian to help.

--- a/build-uclibc.sh
+++ b/build-uclibc.sh
@@ -236,7 +236,8 @@ then
 	--exclude='*.a' -cf - . | tar -xf -
 fi
 
-make distclean >> "${logfile}" 2>&1
+# make may fail but that doesn't hurt, so we need to hide this failure
+make distclean >> "${logfile}" 2>&1 || true
 
 # Patch the temporary install directories used into the uClibc config.
 # uClibc 0.9.34 onwards use defconfig

--- a/run-elf32-tests.sh
+++ b/run-elf32-tests.sh
@@ -51,9 +51,6 @@ mkdir -p ${ARC_GNU}/results
 export DEJAGNU=${ARC_GNU}/toolchain/site.exp
 echo "Running elf32 tests"
 
-# Set the build directories
-bd_elf_gdb=${ARC_GNU}/bd-elf32-gdb
-
 # Create the ELF log file and results directory
 logfile_elf="$(echo "${ARC_GNU}")/logs/elf32-check-$(date -u +%F-%H%M).log"
 rm -f "${logfile_elf}"
@@ -107,13 +104,13 @@ run_check ${bd_elf}     target-libstdc++-v3 "${logfile_elf}" ${board} \
 save_res  ${bd_elf}     ${res_elf} \
     ${target_dir}/libstdc++-v3/testsuite/libstdc++ "${logfile_elf}" \
     || status=1
-run_check ${bd_elf_gdb} sim                 "${logfile_elf}" ${board} \
+run_check ${bd_elf} sim                 "${logfile_elf}" ${board} \
     || status=1
-save_res  ${bd_elf_gdb} ${res_elf} sim/testsuite/sim     "${logfile_elf}" \
+save_res  ${bd_elf} ${res_elf} sim/testsuite/sim     "${logfile_elf}" \
     || status=1
-run_check ${bd_elf_gdb} gdb                 "${logfile_elf}" ${board} \
+run_check ${bd_elf} gdb                 "${logfile_elf}" ${board} \
     || status=1
-save_res  ${bd_elf_gdb} ${res_elf} gdb/testsuite/gdb     "${logfile_elf}" \
+save_res  ${bd_elf} ${res_elf} gdb/testsuite/gdb     "${logfile_elf}" \
     || status=1
 
 exit ${status}


### PR DESCRIPTION
...esn't exist in this version of toolchain.

2013-03-22  Anton Kolesov anton.kolesov@synopsys.com

```
* run-elf32-tests.sh: Fix invalid reference to GDB build directory. GDB
used to be built in separate directory but test script was still trying to
use the old directory.
```
