### PR TITLE
Ignore error with uClibc cleaning when building linux-uclibc toolchain.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2013-03-27	Anton Kolesov <anton.kolesov@synopsys.com>
+
+	* build-uclibc.sh: Ignore error which happens when running 'make
+	distclean' on uClibc. make will fail if there is no .config file already
+	present, but this file is generated only after distclean by defconfig.
+
 2013-03-26  Jeremy Bennett <jeremy.bennett@embecosm.com>
 
 	* dejagnu/telnet-extra.exp (telnet_spawn): Remove duplicate line.

--- a/build-uclibc.sh
+++ b/build-uclibc.sh
@@ -236,7 +236,8 @@ then
 	--exclude='*.a' -cf - . | tar -xf -
 fi
 
-make distclean >> "${logfile}" 2>&1
+# make will fail if there is yet no .config file, but we can ignore this error.
+make distclean >> "${logfile}" 2>&1 || true
 
 # Patch the temporary install directories used into the uClibc config.
 # uClibc 0.9.34 onwards use defconfig


### PR DESCRIPTION
2013-03-27  Anton Kolesov anton.kolesov@synopsys.com

```
* build-uclibc.sh: Ignore error which happens when running 'make
distclean' on uClibc. make will fail if there is no .config file already
present, but this file is generated only after distclean by defconfig.
```
