### PR TITLE
Finalize support of nsim_gdb as a test target for ELF32 tool chain tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2013-05-23	Anton Kolesov <anton.kolesov@synopsys.com>
+
+	* dejagnu/nsim-extra.exp, dejagnu/baseboards/arc-nsim.exp: Change
+	functions where watchdog breakpoints are set from 'abort' and '_exit' to
+	'exit' and '_exit_r', use NSIM_HOME environment variable to start nsim_gdb
+	instance, use option -reconnect of nsim_gdb, use only a limited range of
+	TCP ports for GDB communication.
+
 2013-04-30  Jeremy Bennett <jeremy.bennett@embecosm.com>
 
 	* dejagnu/baseboards/arc-nsim.exp: Load nsim-extra.exp, initialize

--- a/dejagnu/baseboards/arc-nsim.exp
+++ b/dejagnu/baseboards/arc-nsim.exp
@@ -28,29 +28,34 @@
 # This is a list of toolchains that are supported on this board.
 set_board_info target_install ${target_triplet}
 
-# Some extra procs for testing with nSim
-search_and_load_file "library file" "nsim-extra.exp" ${boards_dir}
-
 # Load the generic configuration for this board. This will define a basic set
 # of routines needed by the tool to communicate with the board. Depends on the
 # tool.
 load_generic_config "gdb-comm"
 
+# Some extra procs for testing with nSim. This must go after gdb-comm, as it
+# overrides one of the function in gdb-comm.
+search_and_load_file "library file" "nsim-extra.exp" ${boards_dir}
+
 # Any multilib options are set in an environment variable.
 process_multilib_options "$env(ARC_MULTILIB_OPTIONS)"
+
+set xldflags "-Wl,--defsym=__DEFAULT_HEAP_SIZE=256m -Wl,--defsym=__DEFAULT_STACK_SIZE=32m"
 
 # We only support newlib on this target. We assume that all multilib
 # options have been specified before we get here.
 set_board_info compiler  "[find_gcc]"
 set_board_info cflags    "[libgloss_include_flags] [newlib_include_flags]"
-set_board_info ldflags   "[libgloss_link_flags] [newlib_link_flags]"
+set_board_info ldflags   "[libgloss_link_flags] ${xldflags} [newlib_link_flags]"
 
 # No linker script needed.
 set_board_info ldscript ""
 
 # Use port 51000 as the default to communicate on. This will set the netport
 # (used by gdb-comm) as well as setting up nSim specific data.
-nsim_open 51000
+#set port [exec [file dirname $env(DEJAGNU)]/get-ip.sh --rotate]
+set port 51000
+nsim_open $port
 
 # GDB protocol to be used
 set_board_info gdb_protocol "remote"
@@ -58,9 +63,6 @@ set_board_info gdb_protocol "remote"
 # Use 'continue' instead of 'run' when executing a test
 set_board_info gdb_run_command "continue"
 
-# The simulator doesn't return exit statuses and we need to indicate this;
-# the standard GCC wrapper will work with this target.
-set_board_info needs_status_wrapper  1
 # Doesn't pass arguments or signals, can't return results, and doesn't
 # do inferiorio.
 set_board_info noargs 1

--- a/dejagnu/nsim-extra.exp
+++ b/dejagnu/nsim-extra.exp
@@ -55,12 +55,13 @@ proc nsim_close {} {
 # @param[in] portnum The port number to use
 proc nsim_open { portnum } {
     global board_info board
+    global env env
     verbose "nsim_open $portnum" 3
 
     # Close any existing nSim, then spawn a new one, saving its spawn_id and
     # portnum and setting the netport.
     nsim_close
-    spawn nsim_gdb $portnum
+    spawn "$env(NSIM_HOME)/bin/nsim_gdb" :$portnum "-DLL=$env(NSIM_HOME)/lib/libsim.so" "-props=$env(NSIM_ARCH_PROPS)" -reconnect
     unset_board_info nsim_id
     set_board_info nsim_id $spawn_id
     unset_board_info nsim_port
@@ -93,7 +94,294 @@ proc arc-nsim_reboot { connhost args } {
     set portnum 51000
     if [board_info $board exists nsim_port] {
 	set portnum [board_info $board nsim_port]
-	set portnum [expr { (${portnum} + 1) % 65536 } ]
+	set portnum [expr { (${portnum} + 1) % 4000 + 51000 } ]
     }
     nsim_open $portnum
 }
+
+#
+# This is an override of function defined in gdb-comm.exp
+# Original function defines breakpoints at functions _exit and abort.
+# _exit is not available in ARC newlib. abort is not always available.
+# This modified function sets breakpoints at exit and _exit_r. Though the
+# latter one shouldn't be never hitted.
+#
+# gdb_comm_load -- load the program and execute it
+#
+# PROG is a full pathname to the file to load, no arguments.
+# Result is "untested", "pass", "fail", etc.
+#
+
+proc gdb_comm_load { dest prog args } {
+    global GDB
+    global GDBFLAGS
+    global gdb_prompt
+    global timeout
+    set argnames { "command-line arguments" "input file" "output file" }
+
+    for { set x 0 } { $x < [llength $args] } { incr x } {
+    if { [lindex $args $x] != "" } {
+        return [list "unsupported" "no support for [lindex $argnames $x] on this target"]
+    }
+    }
+    # Make sure the file we're supposed to load really exists.
+    if ![file exists $prog] then {
+    perror "$prog does not exist."
+        return [list "untested" ""]
+    }
+
+    if { [is_remote host] || ![board_info host exists fileid] } {
+    gdb_comm_start $dest
+    }
+
+    # Remove all breakpoints, then tell the debugger that we have
+    # new exec file.
+    if { [gdb_comm_delete_breakpoints] != 0 } {
+    gdb_comm_leave
+    return [gdb_comm_reload $dest $prog $args]
+    }
+    if { [gdb_comm_file_cmd $prog] != 0 } {
+    gdb_comm_leave
+    return [gdb_comm_reload $dest $prog $args]
+    }
+    if [board_info $dest exists gdb_sect_offset] {
+    set textoff [board_info $dest gdb_sect_offset]
+    remote_send host "sect .text $textoff\n"
+    remote_expect host 10 {
+        -re "(0x\[0-9a-z]+) - 0x\[0-9a-z\]+ is \\.data" {
+        set dataoff $expect_out(1,string)
+        exp_continue
+        }
+        -re "(0x\[0-9a-z\]+) - 0x\[0-9a-z\]+ is \\.bss" {
+        set bssoff $expect_out(1,string)
+        exp_continue
+        }
+        -re "$gdb_prompt" { }
+    }
+    set dataoff [format 0x%x [expr $dataoff + $textoff]]
+    set bssoff [format 0x%x [expr $bssoff + $textoff]]
+    remote_send host "sect .data $dataoff\n"
+    remote_expect host 10 {
+        -re "$gdb_prompt" { }
+    }
+    remote_send host "sect .bss $bssoff\n"
+    remote_expect host 10 {
+        -re "$gdb_prompt" { }
+    }
+    }
+
+    # Now set up breakpoints in exit, _exit, and abort.  These
+    # are used to determine if a c-torture test passed or failed.  More
+    # work would be necessary for things like the g++ testsuite which
+    # use printf to indicate pass/fail status.
+
+    # if { [gdb_comm_add_breakpoint _exit] != "" } {
+    gdb_comm_add_breakpoint exit
+    gdb_comm_add_breakpoint _exit_r
+    # }
+    # gdb_comm_add_breakpoint abort
+
+    set protocol [board_info $dest gdb_protocol]
+    if [board_info $dest exists gdb_serial] {
+    set targetname [board_info $dest gdb_serial]
+    } elseif [board_info $dest exists netport] {
+    set targetname [board_info $dest netport]
+    } else {
+    if [board_info $dest exists serial] {
+        set targetname [board_info $dest serial]
+    } else {
+        set targetname ""
+    }
+    }
+    if [board_info $dest exists baud] {
+    remote_send host "set remotebaud [board_info $dest baud]\n"
+    remote_expect host 10 {
+        -re ".*$gdb_prompt $" {}
+        default {
+         warning "failed setting baud rate"
+        }
+    }
+    }
+    remote_send host "target $protocol $targetname\n"
+    remote_expect host 60 {
+    -re "Couldn.t establish conn.*$gdb_prompt $" {
+        warning "Unable to connect to $targetname with GDB."
+        quit_gdb
+        return [gdb_comm_reload $dest $prog $args]
+    }
+    -re "Ending remote.*$gdb_prompt $" {
+        warning "Unable to connect to $targetname with GDB."
+        quit_gdb
+        return [gdb_comm_reload $dest $prog $args]
+    }
+    -re "Remote target $protocol connected to.*$gdb_prompt $" { }
+    -re "Remote target $targetname connected to.*$gdb_prompt $" { }
+    -re "Connected to ARM RDI target.*$gdb_prompt $" { }
+    -re "Connected to the simulator.*$gdb_prompt $" { }
+    -re "Remote.*using $targetname.*$gdb_prompt $" { }
+    -re "$gdb_prompt $" {
+        warning "Unable to connect to $targetname with GDB."
+        quit_gdb
+        return [gdb_comm_reload $dest $prog $args]
+    }
+    -re ".*RDI_open.*should reset target.*" {
+        warning "RDI Open Failed"
+        quit_gdb
+        return [gdb_comm_reload $dest $prog $args]
+    }
+    default {
+        warning "Unable to connect to $targetname with GDB."
+        quit_gdb
+        return [gdb_comm_reload $dest $prog $args]
+    }
+    }
+
+    if [target_info exists gdb_init_command] {
+    remote_send host "[target_info gdb_init_command]\n"
+    remote_expect host 10 {
+        -re ".*$gdb_prompt $" { }
+        default {
+        gdb_comm_leave
+        return [list "fail" ""]
+        }
+    }
+    }
+    # Now download the executable to the target board.  If communications
+    # with the target are very slow the timeout might need to be increased.
+    if [board_info $dest exists gdb_load_offset] {
+    remote_send host "load $prog [board_info $dest gdb_load_offset]\n"
+    } else {
+    remote_send host "load\n"
+    }
+    remote_expect host 600 {
+    -re "text.*data.*$gdb_prompt $" { }
+    -re "data.*text.*$gdb_prompt $" { }
+    -re "$gdb_prompt $" {
+        warning "Unable to send program to target board."
+        gdb_comm_leave
+        return [gdb_comm_reload $dest $prog $args]
+    }
+    default {
+        warning "Unable to send program to target board."
+        gdb_comm_leave
+        return [gdb_comm_reload $dest $prog $args]
+    }
+    }
+
+    set output ""
+
+    # Now start up the program and look for our magic breakpoints.
+    # And a whole lot of other magic stuff too.
+
+    if [board_info $dest exists gdb_run_command] {
+    remote_send host "[board_info $dest gdb_run_command]\n"
+    } else {
+    remote_send host "run\n"
+    }
+    # FIXME: The value 300 below should be a parameter.
+    if [board_info $dest exists testcase_timeout] {
+    set testcase_timeout [board_info $dest testcase_timeout]
+    } else {
+    set testcase_timeout 300
+    }
+    remote_expect host $testcase_timeout {
+    -re "Line.*Jump anyway.*.y or n.*" {
+        remote_send host "y\n"
+        exp_continue
+    }
+    -re "Continuing( at |\\.| with no signal\\.)\[^\r\n\]*\[\r\n\]" {
+        exp_continue
+    }
+    -re ".*Start it from the beginning?.*y or n.*" {
+        remote_send host "n\n"
+        remote_expect host 10 {
+        -re ".*$gdb_prompt $" {
+            remote_send host "signal 0\n"
+            remote_expect host 10 {
+            -re "signal 0\[\r\n\]+" { exp_continue }
+            -re "Continuing(\\.| with no signal\\.)\[\r\n\]" {}
+            }
+        }
+        }
+        exp_continue
+    }
+    -re "(run\[\r\n\]*|)Starting program: \[^\r\n\]*\[\r\n\]" {
+        exp_continue
+    }
+    -re "$gdb_prompt (signal 0|continue)\[\r\n\]+Continuing(\\.| with no signal\\.)\[\r\n\]" {
+        exp_continue
+    }
+    -re "^(.*)Breakpoint.*exit.*=0.*$gdb_prompt $" {
+        append output $expect_out(1,string)
+        set result [check_for_board_status output]
+        gdb_comm_leave
+        if { $result > 0 } {
+        return [list "fail" $output]
+        }
+        return [list "pass" $output]
+    }
+    -re "(.*)Breakpoint.*exit.*=\[1-9\]\[0-9\]*.*$gdb_prompt $" {
+        append output $expect_out(1,string)
+        set result [check_for_board_status output]
+        gdb_comm_leave
+        if { $result == 0 } {
+        return [list "pass" $output]
+        }
+        if [board_info $dest exists exit_statuses_bad] {
+        return [list "pass" $output]
+        }
+        return [list "fail" $output]
+    }
+    -re "(.*)Breakpoint.*exit.*$gdb_prompt $" {
+        append output $expect_out(1,string)
+        set status [check_for_board_status output]
+        gdb_comm_leave
+        if { $status > 0 } {
+        return [list "fail" $output]
+        }
+        return [list "pass" $output]
+    }
+    -re "(.*)Breakpoint.*abort.*$gdb_prompt $" {
+        append output $expect_out(1,string)
+        check_for_board_status output
+        gdb_comm_leave
+        return [list "fail" $output]
+    }
+    -re "SIGTRAP.*$gdb_prompt $" {
+        return [gdb_comm_reload $dest $prog $args]
+    }
+    -re "(.*)Program (received |terminated ).*$gdb_prompt $" {
+        set output $expect_out(1,string)
+        check_for_board_status output
+        gdb_comm_leave
+        remote_reboot $dest
+        return [list "fail" $output]
+    }
+    -re "(.*)Program exited with code \[0-9\]+.*$gdb_prompt $" {
+        set output $expect_out(1,string)
+        set status [check_for_board_status output]
+        gdb_comm_leave
+        if { $status > 0 } {
+        return [list "fail" $output]
+        }
+        return [list "pass" $output]
+    }
+    default {
+        gdb_comm_leave
+        if [board_info $dest exists unreliable] {
+        if { [board_info $dest unreliable] > 0 } {
+            global board_info
+            set name [board_info $dest name]
+            incr board_info($name,unreliable) -1
+            set result [gdb_comm_reload $dest $prog $args]
+            incr board_info($name,unreliable)
+            return $result
+        }
+        }
+        return [list "fail" ""]
+    }
+    }
+    gdb_comm_leave
+    return [list "fail" ""]
+}
+


### PR DESCRIPTION
Please review. 

2013-05-23  Anton Kolesov anton.kolesov@synopsys.com

```
* dejagnu/nsim-extra.exp, dejagnu/baseboards/arc-nsim.exp: Change
functions where watchdog breakpoints are set from 'abort' and '_exit' to
'exit' and '_exit_r', use NSIM_HOME environment variable to start nsim_gdb
instance, use option -reconnect of nsim_gdb, use only a limited range of
TCP ports for GDB communication.
```
