### PR TITLE
Dejagnu + nSIM improvements

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2013-05-31  Anton Kolesov <anton.kolesov@synopsys.com>
+
+	* get-random-port.sh: Script that returns random port number that is free.
+	* dejagnu/nsim-extra.exp, dejagnu/baseboards/arc-nsim.exp: Use
+	get-random-port.sh instead of incremented ports and set very big
+	max_reload_reboots value.
+
 2013-05-23	Anton Kolesov <anton.kolesov@synopsys.com>
 
 	* dejagnu/nsim-extra.exp, dejagnu/baseboards/arc-nsim.exp: Change

--- a/dejagnu/baseboards/arc-nsim.exp
+++ b/dejagnu/baseboards/arc-nsim.exp
@@ -51,10 +51,16 @@ set_board_info ldflags   "[libgloss_link_flags] ${xldflags} [newlib_link_flags]"
 # No linker script needed.
 set_board_info ldscript ""
 
-# Use port 51000 as the default to communicate on. This will set the netport
-# (used by gdb-comm) as well as setting up nSim specific data.
-#set port [exec [file dirname $env(DEJAGNU)]/get-ip.sh --rotate]
-set port 51000
+# nSIM is an exclusive resource -- only one client can connect at a time. For
+# this we cannot use get-ip.sh from arc-linux-nsim.exp, as it doesn't treat
+# target as an exclusive resource. Using script that generates random port
+# allows to leave management of nSIM instances to dejagnu -- it will start,
+# reboot and kill them as needed. get-random-port.sh verifies that generated
+# is free, there is still probability of collision due to race conditions, but
+# it is much less than in other situations.
+# Call to nsim_open will set the netport (used by gdb-comm) as well as setting
+# up nSim specific data.
+set port [exec [file dirname $env(DEJAGNU)]/get-random-port.sh]
 nsim_open $port
 
 # GDB protocol to be used
@@ -62,6 +68,12 @@ set_board_info gdb_protocol "remote"
 
 # Use 'continue' instead of 'run' when executing a test
 set_board_info gdb_run_command "continue"
+
+# On occations GDB cannot connect to nSIM and reboots it. By default amount of
+# reboots is limited to 15, after that all execution tests will be reported as
+# UNTESTED. We need to set an effectively infinite number of reboots so that
+# all execute tests will finish.
+set_board_info max_reload_reboots 1500000
 
 # Doesn't pass arguments or signals, can't return results, and doesn't
 # do inferiorio.

--- a/dejagnu/nsim-extra.exp
+++ b/dejagnu/nsim-extra.exp
@@ -54,8 +54,7 @@ proc nsim_close {} {
 
 # @param[in] portnum The port number to use
 proc nsim_open { portnum } {
-    global board_info board
-    global env env
+    global board_info board env
     verbose "nsim_open $portnum" 3
 
     # Close any existing nSim, then spawn a new one, saving its spawn_id and
@@ -82,7 +81,7 @@ proc nsim_open { portnum } {
 # @param[in] connhost  The connected host (always arc-nsim here)
 # @param[in] args      Any remaining args (unused here)
 proc arc-nsim_reboot { connhost args } {
-    global board_info board
+    global board_info board env
     verbose "arc-nsim_reboot $connhost $args" 3
 
     # Do we have board?
@@ -90,12 +89,8 @@ proc arc-nsim_reboot { connhost args } {
 	set board $connhost
     }
 
-    # Arbitrary default port number
-    set portnum 51000
-    if [board_info $board exists nsim_port] {
-	set portnum [board_info $board nsim_port]
-	set portnum [expr { (${portnum} + 1) % 4000 + 51000 } ]
-    }
+    # Generate random port number.
+    set portnum [exec [file dirname $env(DEJANGU)]/get-random-port.sh]
     nsim_open $portnum
 }
 

--- a/get-random-port.sh
+++ b/get-random-port.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# 20000 : 64000
+begin=20000
+range=44000
+portnum=
+
+while [ -z "${portnum}" ]; do
+    portnum=$(python -c "import random, math; print(int(math.floor(random.random() * ${range} + ${begin})))")
+#    lsof -iTCP -sTCP:LISTEN -Fn | awk -F : '/n*:/ { print $2 }' | grep -q ${portnum}
+    lsof -iTCP -Fn | \
+        awk -F : '/n*:[0-9]+$/ { print $2 } /n*:[0-9]+->/ { print substr($2, 0, index($2, "->") - 1 ) }' | \
+        grep -q ${portnum}
+    if [ $? -eq 0 ]; then
+        portnum=
+    fi
+done
+
+echo "${portnum}"
+


### PR DESCRIPTION
Use random port numbers in dejagnu tests for nSIM, increase value of allowed reboots.
