### PR TITLE
Correct typo in variable name.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2013-06-03  Anton Kolesov <anton.kolesov@synopsys.com>
+
+	* dejagnu/nsim-extra.exp: Correct typo.
+
 2013-05-31  Anton Kolesov <anton.kolesov@synopsys.com>
 
 	* get-random-port.sh: Script that returns random port number that is free.

--- a/dejagnu/nsim-extra.exp
+++ b/dejagnu/nsim-extra.exp
@@ -90,7 +90,7 @@ proc arc-nsim_reboot { connhost args } {
     }
 
     # Generate random port number.
-    set portnum [exec [file dirname $env(DEJANGU)]/get-random-port.sh]
+    set portnum [exec [file dirname $env(DEJAGNU)]/get-random-port.sh]
     nsim_open $portnum
 }
 


### PR DESCRIPTION
2013-06-03  Anton Kolesov anton.kolesov@synopsys.com

```
* dejagnu/nsim-extra.exp: Correct typo.
```
