### PR TITLE
Unset CROSS_COMPILE environment variable in build scripts

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2013-08-12	Anton Kolesov	<akolesov@synopsys.com>
+
+	* build-all.sh: Unset environment variable CROSS_COMPILE. Tools makefiles
+	recognize this variable, so we need to unset it, otherwise standard
+	libraries will be be built with toolchain pointed by CROSS_COMPILE, which
+	is undesirable.
+
 2013-07-12  Jeremy Bennett  <jeremy.bennett@embecosm.com>
 
 	* arc-versions.sh: Switch to use arc-gdb-mainline for GDB

--- a/build-all.sh
+++ b/build-all.sh
@@ -243,6 +243,9 @@ unset commentstamp
 unset jobs
 unset load
 unset DISABLEWERROR
+# Tools makefiles recognize this variable, so we need to unset it, otherwise
+# standard libraries will be be built with toolchain pointed by CROSS_COMPILE.
+unset CROSS_COMPILE
 
 # In bash we typically write function blah_blah () { }. However Ubuntu default
 # /bin/sh -> dash doesn't recognize the "function" keyword. Its exclusion


### PR DESCRIPTION
Tools makefiles recognize this variable, so we need to unset it, otherwise standard libraries will be be built with toolchain pointed by CROSS_COMPILE, which is undesirable. For example if it is set to little endian toolchain and script builds big endian toolchain then standard libraries will be little endian rendering toolchain unusable. In more dangerous case endianness will match, but standard libraries will be build with other compiler and there would be no easy way to notice this.
