### PR TITLE
Add option to auto download GMP, MPFR and MPC

### DIFF
--- a/arc-versions.sh
+++ b/arc-versions.sh
@@ -5,6 +5,7 @@
 # Copyright (C) 2012, 2013 Synopsys Inc.
 
 # Contributor Jeremy Bennett <jeremy.bennett@embecosm.com>
+# Contributor Anton Kolesov <akolesov@synopsys.com>
 
 # This script is sourced to specify the versions of tools to be built.
 
@@ -26,6 +27,7 @@
 
 #     arc-versions.sh [--auto-checkout | --no-auto-checkout]
 #                     [--auto-pull | --no-auto-pull]
+#                     [--auto-download | --no-auto-download]
 
 # The environment variable ${ARC_GNU} should point to the directory within
 # which the GIT trees live.
@@ -39,6 +41,7 @@
 # Default options
 autocheckout="--auto-checkout"
 autopull="--auto-pull"
+autodownload="--auto-download"
 
 # Parse options
 until
@@ -52,9 +55,14 @@ case ${opt} in
 	autopull=$1
 	;;
 
+    --auto-download | --no-auto-download)
+    autodownload=$1
+    ;;
+
     ?*)
 	echo "Usage: arc-versions.sh  [--auto-checkout | --no-auto-checkout]"
         echo "                        [--auto-pull | --no-auto-pull]"
+        echo "                        [--auto-download | --no-auto-download]"
 	exit 1
 	;;
 
@@ -163,3 +171,46 @@ do
 	fi
     fi
 done
+
+# Download dependencies if we have been asked to
+if [ "x${autodownload}" = "x--auto-download" ]
+then
+
+    echo "Downloading dependencies..."
+    cd ${ARC_GNU}/gcc
+
+    # GMP 4.3.2
+    if [ ! -d gmp ]; then
+        echo "Getting GMP 4.3.2"
+        gmp_tar=gmp-4.3.2.tar.bz2
+        if [ ! -f $gmp_tar ]; then
+            wget -nv ftp://ftp.gmplib.org/pub/gmp/$gmp_tar
+            tar xjf $gmp_tar
+        fi
+        mv gmp-4.3.2 gmp
+    fi
+    
+    # MPFR 2.4.2
+    if [ ! -d mpfr ]; then
+        echo "Getting MPFR 2.4.2"
+        mpfr_tar=mpfr-2.4.2.tar.bz2
+        if [ ! -f $mpfr_tar ]; then
+            wget -nv http://www.mpfr.org/mpfr-2.4.2/$mpfr_tar
+        fi
+        tar xjf $mpfr_tar
+        mv mpfr-2.4.2 mpfr
+    fi
+    
+    # MPC 1.0.1
+    if [ ! -d mpc ]; then
+        echo "Getting MPC 1.0.1"
+        mpc_tar=mpc-1.0.1.tar.gz
+        if [ ! -f $mpc_tar ]; then
+            wget -nv http://www.multiprecision.org/mpc/download/$mpc_tar
+        fi
+        tar xzf $mpc_tar
+        mv mpc-1.0.1 mpc
+    fi
+
+fi
+

--- a/build-all.sh
+++ b/build-all.sh
@@ -3,6 +3,7 @@
 # Copyright (C) 2012, 2013 Synopsys Inc.
 
 # Contributor Jeremy Bennett <jeremy.bennett@embecosm.com>
+# Contributor Anton Kolesov <akolesov@synopsys.com>
 
 # This file is a master script for building ARC tool chains.
 
@@ -29,6 +30,7 @@
 #                  [--symlink-dir <symlink_dir>]
 #                  [--auto-pull | --no-auto-pull]
 #                  [--auto-checkout | --no-auto-checkout]
+#                  [--auto-download | --no-auto-download]
 #                  [--unisrc | --no-unisrc]
 #                  [--elf32 | --no-elf32] [--uclibc | --no-uclibc]
 #                  [--datestamp-install]
@@ -115,6 +117,15 @@
 
 #     If specified, a "git pull" will be done in each component repository
 #     after checkout to ensure the latest code is in use. Default is to pull.
+
+# --auto-download | --no-auto-download
+
+#     If specified, then GMP, MPFR and MPC libraries will be downloaded as
+#     source tarballs, unpacked and placed inside GCC source directory. GCC
+#     makefiles will recognize those directories properly and will use them
+#     instead of system libraries. Some systems (RHEL, CentOS) doesn't have all
+#     of the required dependencies in official repositaries. This is done right
+#     after checkout and before unisrc is created. Default is to download.
 
 # --unisrc | --no-unisrc
 
@@ -238,6 +249,7 @@ unset ARC_ENDIAN
 unset PARALLEL
 unset autocheckout
 unset autopull
+unset autodownload
 unset datestamp
 unset commentstamp
 unset jobs
@@ -273,6 +285,7 @@ build_pathnm ()
 # Set defaults for some options
 autocheckout="--auto-checkout"
 autopull="--auto-pull"
+autodownload="--auto-download"
 do_unisrc="--unisrc"
 elf32="--elf32"
 uclibc="--uclibc"
@@ -353,6 +366,10 @@ case ${opt} in
     --auto-pull | --no-auto-pull)
 	autopull=$1
 	;;
+
+    --auto-download | --no-auto-download)
+    autodownload=$1
+    ;;
 
     --unisrc | --no-unisrc)
 	do_unisrc=$1
@@ -460,6 +477,7 @@ case ${opt} in
         echo "                      [--install-dir <install_dir>]"
 	echo "                      [--symlink-dir <symlink_dir>]"
 	echo "                      [--auto-checkout | --no-auto-checkout]"
+        echo "                      [--auto-download | --no-auto-download]"
         echo "                      [--auto-pull | --no-auto-pull]"
         echo "                      [--unisrc | --no-unisrc]"
         echo "                      [--elf32 | --no-elf32]"
@@ -629,7 +647,7 @@ echo "======================" >> "${logfile}"
 
 echo "Checking out GIT trees ..."
 if ! ${ARC_GNU}/toolchain/arc-versions.sh ${autocheckout} ${autopull} \
-      >> ${logfile} 2>&1
+    ${autodownload} >> ${logfile} 2>&1
 then
     echo "ERROR: Failed to checkout GIT versions of tools"
     echo "- see ${logfile}"


### PR DESCRIPTION
Let me know if you want me to change something. I prefer this option to be ON by default.

GCC depends on GMP, MPFR and MPC. However on some systems, notably RHEL/CentOS, those packages are not available in official repositaries or only obsolete versions are available. With this patch arc-versions.sh will download source tarballs of these dependencies and place them inside gcc directory. GCC makefiles are smart enough to use those instead of packages installed on system. Those dependencies will be linked statically inside GCC.
