### PR TITLE
Add option to auto download GMP, MPFR and MPC

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2013-09-04	Anton Kolesov <akolesov@synopsys.com>
+
+	* arc-external.sh: New file to download external dependencies.
+	* build-all.sh: New option --[no-]external-download.
+
 2013-09-03  Jeremy Bennett <jeremy.bennett@embecosm.com>
 
 	* arc-versions.sh: Only use Linux if --uclibc is set (new

--- a/arc-external.sh
+++ b/arc-external.sh
@@ -1,0 +1,32 @@
+#!/bin/sh -e
+
+# Download some external dependencies. Return non-zero status if there is an error.
+
+urls='
+ftp://ftp.gmplib.org/pub/gmp/gmp-4.3.2.tar.bz2
+http://www.mpfr.org/mpfr-2.4.2/mpfr-2.4.2.tar.bz2
+http://www.multiprecision.org/mpc/download/mpc-1.0.1.tar.gz
+'
+
+for url in ${urls} ; do
+    filename="$(echo "${url}" | sed 's/^.*\///')"
+    dirname="$(echo "${filename}" | sed 's/\.tar\..*$//')"
+    toolname="$(echo "${dirname}" | cut -d- -f1)"
+    
+    if echo "${filename}" | grep -q .tar.bz2 ; then
+        tar="tar xjf"
+    else
+        tar="tar xzf"
+    fi
+
+    if [ ! -d "${toolname}" ]; then
+        if [ ! -d "${dirname}" ]; then
+            if [ ! -f "${filename}" ]; then
+                wget -nv "${url}"
+            fi
+            ${tar} "${filename}"
+        fi
+        mv "${dirname}" "${toolname}"
+    fi
+done
+

--- a/build-all.sh
+++ b/build-all.sh
@@ -29,6 +29,7 @@
 #                  [--symlink-dir <symlink_dir>]
 #                  [--auto-pull | --no-auto-pull]
 #                  [--auto-checkout | --no-auto-checkout]
+#                  [--external-download | --no-external-download]
 #                  [--unisrc | --no-unisrc]
 #                  [--elf32 | --no-elf32] [--uclibc | --no-uclibc]
 #                  [--datestamp-install]
@@ -115,6 +116,15 @@
 
 #     If specified, a "git pull" will be done in each component repository
 #     after checkout to ensure the latest code is in use. Default is to pull.
+
+# --external-download | --no-external-download
+
+#     If specified, then GMP, MPFR and MPC libraries will be downloaded as
+#     source tarballs, unpacked and placed inside GCC source directory. GCC
+#     makefiles will recognize those directories properly and will use them
+#     instead of system libraries. Some systems (RHEL, CentOS) doesn't have all
+#     of the required dependencies in official repositories. This is done right
+#     after checkout and before unisrc is created. Default is to download.
 
 # --unisrc | --no-unisrc
 
@@ -238,6 +248,7 @@ unset ARC_ENDIAN
 unset PARALLEL
 unset autocheckout
 unset autopull
+unset external_download
 unset datestamp
 unset commentstamp
 unset jobs
@@ -273,6 +284,7 @@ build_pathnm ()
 # Set defaults for some options
 autocheckout="--auto-checkout"
 autopull="--auto-pull"
+external_download="--external-download"
 do_unisrc="--unisrc"
 elf32="--elf32"
 uclibc="--uclibc"
@@ -352,6 +364,10 @@ case ${opt} in
 
     --auto-pull | --no-auto-pull)
 	autopull=$1
+	;;
+
+	--external-download | --no-external-download)
+	external_download=$1
 	;;
 
     --unisrc | --no-unisrc)
@@ -461,6 +477,7 @@ case ${opt} in
 	echo "                      [--symlink-dir <symlink_dir>]"
 	echo "                      [--auto-checkout | --no-auto-checkout]"
         echo "                      [--auto-pull | --no-auto-pull]"
+	echo "                      [--external-download | --no-external-download]"
         echo "                      [--unisrc | --no-unisrc]"
         echo "                      [--elf32 | --no-elf32]"
         echo "                      [--uclibc | --no-uclibc]"
@@ -635,6 +652,21 @@ then
     echo "ERROR: Failed to checkout GIT versions of tools"
     echo "- see ${logfile}"
     exit 1
+fi
+
+# Downloading external dependencies
+if [ "x${external_download}" = "x--external-download" ]; then
+    echo "Downloading external dependencies" >> "${logfile}"
+    echo "====================================" >> "${logfile}"
+
+    echo "Downloading external dependencies..."
+	cd ${ARC_GNU}/gcc
+    if ! ${ARC_GNU}/toolchain/arc-external.sh >> ${logfile} 2>&1
+    then
+        echo "WARNING: Failed to download external dependencies. Build will be continued but it can fail."
+    fi
+else
+    echo "Will not download external dependencies" | tee -a "${logfile}"
 fi
 
 # Change to the build directory


### PR DESCRIPTION
GCC depends on GMP, MPFR and MPC. However on some systems, notably
RHEL/CentOS, those packages are not available in official repositories or
only obsolete versions are available. With this patch arc-versions.sh will
download source tarballs of these dependencies and place them inside gcc
directory. GCC makefiles are smart enough to use those instead of packages
installed on system. Those dependencies will be linked statically inside
GCC.

I've checked this script on Ubuntu 13.04 and RHEL 6.4.
