### PR TITLE
Add support for stripped host installation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2013-09-16  Anton Kolesov <akolesov@synopsys.com>
+
+	* build-all.sh: Add option --[no-]strip to strip host binaries from symbols.
+	* build-elf32.sh: Use HOST_INSTALL env variable to define which target to
+	use to install on host. Should be either `install' or `install-strip'.
+	* build-uclibc.sh: Likewise.
+
 2013-09-11  Anton Kolesov <akolesov@synopsys.com>
 
 	* dejagnu/baseboard/arc-nsim.exp: Correct configuration for GDB testsuite

--- a/build-all.sh
+++ b/build-all.sh
@@ -45,6 +45,7 @@
 #                  [--pdf | --no-pdf]
 #                  [--rel-rpaths | --no-rel-rpaths]
 #                  [--disable-werror | --no-disable-werror]
+#                  [--strip | --no-strip]
 
 # This script is a convenience wrapper to build the ARC GNU 4.4 tool
 # chains. It utilizes Joern Rennecke's build-elf32.sh script and Bendan
@@ -228,6 +229,11 @@
 #     Use these to control whether the tools are built with --disable-werror
 #     (default --disable-werror).
 
+# --strip | --no-strip
+
+#     Install stripped host binaries. Target libraries are not affected.
+#     Default is --no-strip.
+
 # Where directories are specified as arguments, they are relative to the
 # current directory, unless specified as absolute names.
 
@@ -254,6 +260,7 @@ unset commentstamp
 unset jobs
 unset load
 unset DISABLEWERROR
+unset HOST_INSTALL
 
 # In bash we typically write function blah_blah () { }. However Ubuntu default
 # /bin/sh -> dash doesn't recognize the "function" keyword. Its exclusion
@@ -295,6 +302,7 @@ DO_PDF="--pdf"
 rel_rpaths="--no-rel-rpaths"
 DISABLEWERROR="--disable-werror"
 CFLAGS_FOR_TARGET=""
+HOST_INSTALL=install
 
 # Default multilib usage and conversion for toolchain building
 case "x${DISABLE_MULTILIB}" in
@@ -467,6 +475,14 @@ case ${opt} in
 	DISABLEWERROR=
 	;;
 
+    --strip)
+        HOST_INSTALL=install-strip
+        ;;
+
+    --no-strip)
+        HOST_INSTALL=install
+        ;;
+
     ?*)
 	echo "Unknown argument $1"
 	echo
@@ -495,6 +511,7 @@ case ${opt} in
 	echo "                      [--pdf | --no-pdf]"
 	echo "                      [--rel-rpaths | --no-rel-rpaths]"
 	echo "                      [--disable-werror | --no-disable-werror]"
+	echo "                      [--strip | --no-strip]"
 	exit 1
 	;;
 
@@ -602,6 +619,7 @@ export DO_PDF
 export PARALLEL
 export UCLIBC_DEFCFG
 export DISABLEWERROR
+export HOST_INSTALL
 if [ "x${CFLAGS_FOR_TARGET}" != "x" ]
 then
     export CFLAGS_FOR_TARGET

--- a/build-elf32.sh
+++ b/build-elf32.sh
@@ -97,6 +97,11 @@
 
 #     string "-j <jobs> -l <load>" to control parallel make.
 
+# HOST_INSTALL
+
+#     Make target prefix to install host application. Should be either
+#     "install" or "install-strip".
+
 # We source the script arc-init.sh to set up variables needed by the script
 # and define a function to get to the configuration directory (which can be
 # tricky under MinGW/MSYS environments).
@@ -158,6 +163,7 @@ if [ "x${DO_SIM}" = "x--sim" ]
 then
     sim_config="--enable-sim --enable-sim-endian=no"
     sim_build=all-sim
+    # CGEN doesn't have install-strip target.
     sim_install=install-sim
     sed -i "${ARC_GNU}"/gdb/gdb/configure.tgt \
 	-e 's!# gdb_sim=../sim/arc/libsim.a!gdb_sim=../sim/arc/libsim.a!'
@@ -234,9 +240,10 @@ echo "Installing tools ..."
 build_path=$(calcConfigPath "${build_dir}")
 cd "${build_path}"
 log_path=$(calcConfigPath "${logfile}")
-if make install-binutils install-gas install-ld install-gcc \
-        install-target-libgcc install-target-libgloss install-target-newlib \
-        install-target-libstdc++-v3 ${sim_install} install-gdb \
+if make ${HOST_INSTALL}-binutils ${HOST_INSTALL}-gas ${HOST_INSTALL}-ld \
+    ${HOST_INSTALL}-gcc ${sim_install} install-gdb \
+    install-target-libgloss install-target-newlib install-target-libgcc \
+    install-target-libstdc++-v3 \
     >> "${log_path}" 2>&1
 then
     echo "  finished installing tools"

--- a/build-uclibc.sh
+++ b/build-uclibc.sh
@@ -97,6 +97,11 @@
 
 #     string "-j <jobs> -l <load>" to control parallel make.
 
+# HOST_INSTALL
+
+#     Make target prefix to install host application. Should be either
+#     "install" or "install-strip".
+
 # Unlike earlier versions of this script, we do not recognize the
 # ARC_GNU_ONLY_CONFIGURE and ARC_GNU_CONTINUE environment variables. If you
 # are using this script, you need to run the whole thing. If you want to redo
@@ -488,8 +493,9 @@ else
     exit 1
 fi
 
-if make install-binutils install-gas install-ld install-gcc \
-        install-target-libgcc install-target-libstdc++-v3 >> "${logfile}" 2>&1
+if make ${HOST_INSTALL}-binutils ${HOST_INSTALL}-gas ${HOST_INSTALL}-ld \
+    ${HOST_INSTALL}-gcc install-target-libgcc install-target-libstdc++-v3 \
+	>> "${logfile}" 2>&1
 then
     echo "  finished installing stage 2 tool chain"
 else


### PR DESCRIPTION
Add option --[no-]strip to strip host binaries from symbols. Symbols usually
don't make sense for end users but waste a lot of space. If --strip option
is specified than host applications will be installed using target
install-strip, instead of default install. GDB and CGEN are not affected
because they do not support this install target and I don't want to
workaround this by stripping them manually from the script. Stripping is
optional, by default toolchain is with debug symbols.
