### PR TITLE
Fix double usage of same variable name

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2013-09-26  Anton Kolesov <akolesov@synopsys.com>
+
+	* arc-versions.sh: Fix double usage of same variable name for different
+	purposes, leading to incorrect behaviour.
+
 2013-09-16  Anton Kolesov <akolesov@synopsys.com>
 
 	* build-all.sh: Add option --[no-]strip to strip host binaries from symbols.

--- a/arc-versions.sh
+++ b/arc-versions.sh
@@ -40,7 +40,7 @@
 # Default options
 autocheckout="--auto-checkout"
 autopull="--auto-pull"
-uclibc="--uclibc"
+uclibc_arg="--uclibc"
 
 # Parse options
 until
@@ -55,7 +55,7 @@ case ${opt} in
 	;;
 
     --uclibc | --no-uclibc)
-	uclibc=$1
+	uclibc_arg=$1
 	;;
 
     ?*)
@@ -85,7 +85,7 @@ gdb="gdb:arc-mainline-dev"
 newlib="newlib:arc-2.0-dev"
 uclibc="uClibc:arc-mainline-dev"
 
-if [ "x${uclibc}" = "x--uclibc" ]
+if [ "x${uclibc_arg}" = "x--uclibc" ]
 then
     linux="linux:arc-3.9"
 else


### PR DESCRIPTION
Hat tip to Vineet for noticing.

But! I've noticed that since --no-uclibc disables checkout for linux, it happens that command "--no-uclibc --no-elf32 --no-unisrc" which is intended to checkout tree to known state will leave linux as is.
