### PR TITLE
Fix error when build elf32-only toolchain with --rel-rpaths

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2013-09-30  Anton Kolesov <akolesov@synopsys.com>
+
+	* rel-rpaths.sh: Check that uClibc libc.so file exists before trying to
+	update it. Otherwise script fails for elf32-only toolchain build.
+
 2013-09-26  Anton Kolesov <akolesov@synopsys.com>
 
 	* arc-versions.sh: Fix double usage of same variable name for different

--- a/rel-rpaths.sh
+++ b/rel-rpaths.sh
@@ -25,7 +25,7 @@ REPLACEDIR=${INSTALLDIR}
 cd ${REPLACEDIR}
 
 if ! [ -d bin ]; then
-    echo "Should run $0 in INSTALL directory"
+    echo "\`$INSTALLDIR' is not a toolchain installation directory."
     exit 1
 fi
 
@@ -63,8 +63,12 @@ then
 else
     arch=arc
 fi
-sed -e "s#${REPLACEDIR}/${arch}-linux-uclibc/lib/##g" < \
-    ${arch}-linux-uclibc/lib/libc.so > _libc.so
-mv _libc.so ${arch}-linux-uclibc/lib/libc.so
+uclibc_libc_path=${arch}-linux-uclibc/lib/libc.so
+if [ -f $uclibc_libc_path ]; then
+    sed -e "s#${REPLACEDIR}/${arch}-linux-uclibc/lib/##g" < \
+        $uclibc_libc_path > _libc.so
+    mv _libc.so $uclibc_libc_path
+fi
 
+# vi: set expandtab:
 


### PR DESCRIPTION
Script rel-rpaths.sh was trying to update uClibc-specific libc.so file
unconditionally. As a result elf32-only toolchain build was failing. This
patch adds a check that whether libc.so file actually exists before trying
to update it.

Signed-off-by: Anton Kolesov akolesov@synopsys.com
