### PR TITLE
Linux sources details, auto-pull/checkout

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2013-10-30  Anton Kolesov  <anton.kolesov@synopsys.com>
+
+	* build-all.sh: Give more detailed error message if Linux sources are
+	mussing.
+	* README.md: Add details on getting Linux sources.
+
 2013-10-29  Anton Kolesov  <anton.kolesov@synopsys.com>
 
 	* README.md: Add example of usage with Opella-XD debug probe.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 2013-10-30  Anton Kolesov  <anton.kolesov@synopsys.com>
 
+	* build-all.sh: Decide default value for auto-pull/checkout based on
+	whether toolchain directory is a Git repository or not. Checkout and
+	pull if it is a repository and do nothing if it is a directory from
+	source tarball.
+
+2013-10-30  Anton Kolesov  <anton.kolesov@synopsys.com>
+
 	* build-all.sh: Give more detailed error message if Linux sources are
 	mussing.
 	* README.md: Add details on getting Linux sources.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,23 @@ top level of the gcc repository.
 Getting sources
 ---------------
 
+###  Using source tarball
+
+If you use source tarball then it already contains all of the necessary sources
+except for Linux which is a separate product. Linux sources are required only
+for linux-uclibc tool chain, they are not required for baremetal elf32 tool
+chain.  Latest stable release from https://kernel.org/ is recommended, only
+versions >= 3.9 are supported. Untar linux tarball to the directory named
+\`linux' that is the sibling of this \`toolchain' directory. For example,
+assuming your current directory is \`toolchain\':
+
+    $ cd ..
+    $ wget https://www.kernel.org/pub/linux/kernel/v3.x/linux-3.11.6.tar.xz
+    $ tar xaf linux-3.11.6.tar.xz --transform=s/linux-3.11.6/linux/
+    $ cd toolchain
+
+### Using Git repositories
+
 You need to check out the repositories for each of the tool chain
 components (its not all one big repository), including the linux repository
 for building the tool chain. These should be peers of this toolchain

--- a/build-all.sh
+++ b/build-all.sh
@@ -538,8 +538,12 @@ then
     then
 	LINUXDIR="${ARC_GNU}"/linux
     else
-	echo "ERROR: Cannot find Linux sources."
-	exit 1
+        echo "ERROR: Cannot find Linux sources. You can download latest"\
+             "stable release from http://kernel.org and untar it as a"\
+             "sibling of this \`toolchain' directory. Directory name must"\
+             "be \`linux'. For more details read README.md file, section"\
+             "\"Obtaining sources/Using source tarball\"."
+	     exit 1
     fi
 fi
 

--- a/build-all.sh
+++ b/build-all.sh
@@ -111,12 +111,16 @@
 # --auto-checkout | --no-auto-checkout
 
 #     If specified, a "git checkout" will be done in each component repository
-#     to ensure the correct branch is checked out. Default is to checkout.
+#     to ensure the correct branch is checked out. If tool chain is built from
+#     a source tarball then default is to not make a checkout. If tool chain is
+#     built from a Git repository then default is to make a checkout.
 
 # --auto-pull | --no-auto-pull
 
 #     If specified, a "git pull" will be done in each component repository
 #     after checkout to ensure the latest code is in use. Default is to pull.
+#     If tool chain is built from a source tarball then default is to not pull.
+#     If tool chain is built from a Git repository then default is to pull.
 
 # --external-download | --no-external-download
 
@@ -289,8 +293,8 @@ build_pathnm ()
 }
 
 # Set defaults for some options
-autocheckout="--auto-checkout"
-autopull="--auto-pull"
+autocheckout=""
+autopull=""
 external_download="--external-download"
 do_unisrc="--unisrc"
 elf32="--elf32"
@@ -528,6 +532,25 @@ if [ "x${ARC_GNU}" = "x" ]
 then
     d=`dirname "$0"`
     ARC_GNU=`(cd "$d/.." && pwd)`
+fi
+
+# Now we can decide if do auto pull and auto checkout
+if [ -d "$ARC_GNU/toolchain/.git" ]
+then
+    git_auto="--auto"
+else
+    git_auto="--no-auto"
+fi
+echo "$git_auto"
+
+if [ "x${autopull}" = "x" ]
+then
+    autopull="${git_auto}-pull"
+fi
+
+if [ "x${autocheckout}" = "x" ]
+then
+    autocheckout="${git_auto}-checkout"
 fi
 
 # Default Linux directory if not already set. Only matters if we are building


### PR DESCRIPTION
Two changes:
1) More detailed error message if no linux sources
2) do not make pull/checkout if we are building from tarball.
