### PR TITLE
Improve error messages when pdf builds fails

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2013-11-18  Anton Kolesov  <anton.kolesov@synopsys.com>
+
+	* build-elf32.sh, build-uclibc.sh: If PDF docs build failed, suggest
+	user to read Prerequisites section of documentation or use option
+	--no-pdf.
+
 2013-11-12  Anton Kolesov  <anton.kolesov@synopsys.com>
 
 	* build-all.sh: Fix reference to section from readme, invalid name has

--- a/build-elf32.sh
+++ b/build-elf32.sh
@@ -272,6 +272,11 @@ then
 	echo "  finished building PDFs"
     else
 	echo "ERROR: PDF build failed."
+	echo "Advice: Use option --no-pdf if you don't need PDF documentation."
+	if ! which texi2pdf >/dev/null 2>/dev/null ; then
+	    echo "Is TeX installed? See section Prerequisites of " \
+	         "GCC Getting Started for a list of required system packages."
+	fi
 	exit 1
     fi
 

--- a/build-uclibc.sh
+++ b/build-uclibc.sh
@@ -596,6 +596,11 @@ then
 	echo "  finished building PDFs"
     else
 	echo "ERROR: PDF build failed."
+	echo "Advice: Use option --no-pdf if you don't need PDF documentation."
+	if ! which texi2pdf >/dev/null 2>/dev/null ; then
+	    echo "Is TeX installed? See section Prerequisites of " \
+	         "GCC Getting Started for a list of required system packages."
+	fi
 	exit 1
     fi
 


### PR DESCRIPTION
If PDF docs build failed, suggest user to read Prerequisites section of
documentation or use option --no-pdf.

Signed-off-by: Anton Kolesov anton.kolesov@synopsys.com
