### PR TITLE
Add DejaGNU board file for Metaware+nSIM

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2013-12-24  Anton Kolesov  <anton.kolesov@synopsys.com>
+
+	* run-tests.sh: Add hostlink library option.
+	* dejagnu/mdbsim.sh: New file, shell wrapper around mdb.
+	* dejagnu/baseboards/arc-sim-mdb.exp: New file, board definition to
+	use Metaware Debugger as an interface to nSIM.
+
 2013-12-20  Anton Kolesov  <anton.kolesov@synopsys.com>
 
 	* arc-init.sh: Remove extra bashbang.

--- a/dejagnu/baseboards/arc-sim-mdb.exp
+++ b/dejagnu/baseboards/arc-sim-mdb.exp
@@ -1,0 +1,73 @@
+# Copyright (C) 1997, 1998, 1999, 2000, 2001, 2002, 2003 Free Software
+# Foundation, Inc.
+#
+# Copyright (C) 2013 Synopsys, Inc.
+#
+# Contributor: Anton Kolesov <anton.kolesov@synopsys.com>
+# Contributor: Claudiu Zissulescu <Claudiu.Zissulescu@synopsys.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+# This is a list of toolchains that are supported on this board.
+set_board_info target_install ${target_triplet}
+
+# Load the generic configuration for this board. This will define a basic set
+# of routines needed by the tool to communicate with the board.
+load_generic_config "sim"
+
+# basic-sim.exp is a basic description for the standard Cygnus simulator.
+load_base_board_description "basic-sim"
+
+# Any multilib options are set in an environment variable.
+set multilib_opts "$env(ARC_MULTILIB_OPTIONS)"
+process_multilib_options "$multilib_opts"
+
+set xldflags "-Wl,--defsym=__DEFAULT_HEAP_SIZE=256m -Wl,--defsym=__DEFAULT_STACK_SIZE=1024m"
+
+# Hostlink library support
+if { [ info exists env(ARC_HOSTLINK_LIBRARY) ] } {
+   set xldflags "$xldflags -Wl,--whole-archive $env(ARC_HOSTLINK_LIBRARY) -Wl,--no-whole-archive"
+}
+
+# EM is default
+set xarchflags "-Xdpfp -Xspfp -Xlib"
+if { [string first ARC700 "$multilib_opts"] == 0 } {
+    set xarchflags "-a7 $xarchflags"
+} elseif { [string first HS "$multilib_opts"] == 0 } {
+    set xarchflags "-av2hs $xarchflags"
+} else {
+    set xarchflags "-av2em $xarchflags"
+}
+
+# Setup the MetaWare simulator.
+set SIM_PATH "[file dirname $env(DEJAGNU)]/dejagnu"
+set_board_info sim "${SIM_PATH}/mdbsim.sh ${xarchflags} "
+set_board_info sim_time_limit 120
+set_board_info is-simulator 1
+
+# We only support newlib on this target. We assume that all multilib
+# options have been specified before we get here.
+set_board_info compiler  "[find_gcc]"
+set_board_info cflags    "[libgloss_include_flags] [newlib_include_flags]"
+set_board_info ldflags   "[libgloss_link_flags] ${xldflags} [newlib_link_flags]"
+
+# No linker script needed.
+set_board_info ldscript ""
+
+# Doesn't pass arguments or signals, can't return results, and doesn't
+# do inferiorio.
+set_board_info noargs 1
+set_board_info gdb,nosignals 1
+set_board_info gdb,noresults 1
+set_board_info gdb,noinferiorio 1

--- a/dejagnu/mdbsim.sh
+++ b/dejagnu/mdbsim.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+mdb -nsim -noproject -nooptions -run $*
+RET=$?
+echo "*** EXIT code ${RET}"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -74,6 +74,10 @@
 #    matches multilib and endian options. This option makes sense only when
 #    target board is arc-nsim.
 
+# --elf32-hostlink-library <path/to/hostlink/library>
+
+#    Path to hostlink library archive. Required for test runs with Metaware.
+
 # --jobs <count>
 
 #     Specify that parallel make should run at most <count> jobs. The default
@@ -135,6 +139,7 @@ ARC_TEST_ADDR_ELF32=
 ARC_TEST_ADDR_UCLIBC=aa4_32
 ARC_MULTILIB_OPTIONS=""
 ARC_NSIM_PROPS="${NSIM_HOME}/systemc/configs/nsim_a700.props"
+ARC_HOSTLINK_LIBRARY=
 make_load="`(echo processor; cat /proc/cpuinfo 2>/dev/null echo processor) \
            | grep -c processor`"
 jobs=${make_load}
@@ -185,6 +190,11 @@ case ${opt} in
     shift
     ARC_NSIM_PROPS=$1
     ;;
+
+    --elf32-hostlink-library)
+	shift
+	ARC_HOSTLINK_LIBRARY=$1
+	;;
 
     --jobs)
 	shift
@@ -310,6 +320,7 @@ case ${opt} in
         echo "                      [--elf32-target-addr <address>]"
         echo "                      [--uclibc-target-addr <address>]"
         echo "                      [--elf32-nsim-props <path>]"
+        echo "                      [--elf32-hostlink-library <path>]"
         echo "                      [--elf32 | --no-elf32]"
         echo "                      [--uclibc | --no-uclibc]"
         echo "                      [--big-endian | --little-endian]"
@@ -380,6 +391,11 @@ export DO_NEWLIB
 export DO_LIBSTDCPP
 export DO_SIM
 export DO_GDB
+
+if [ "x${ARC_HOSTLINK_LIBRARY}" != x ]
+then
+    export ARC_HOSTLINK_LIBRARY
+fi
 
 status=0
 


### PR DESCRIPTION
New board definition (arc-sim-mdb) uses nSIM directly to run compiler tests,
instead of using GDB + nSIM_gdb combination. This board doesn't support GDB
as a test target. MetaWare is used as an interface to nSIM.

Signed-off-by: Anton Kolesov anton.kolesov@synopsys.com
