### PR TITLE
Build gdbserver with compiler optimizations

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2014-02-07  Anton Kolesov  <anton.kolesov@synopsys.com>
+
+	* build-uclibc.sh: Build gdbserver with -O3 instead of -O0, use
+	CFLAGS_FOR_TARGET properly for gdbserver.
+
 2014-01-28  Anton Kolesov  <anton.kolesov@synopsys.com>
 
 	* build-all.sh: Replace --isa-* options with --cpu option.

--- a/build-uclibc.sh
+++ b/build-uclibc.sh
@@ -565,7 +565,7 @@ fi
 CC=${arche}-linux-uclibc-gcc
 export CC
 if make ${PARALLEL} \
-    CFLAGS="${CFLAGS} -static -fcommon -mno-sdata" \
+    CFLAGS="-static -fcommon -mno-sdata -O3 ${CFLAGS_FOR_TARGET}" \
     >> "${logfile}" 2>&1
 then
     echo "  finished building GDBSERVER to run on an arc"


### PR DESCRIPTION
Gdbserver for some reason was built without optimization level, making it
-O0. It is not noticeable in most user scenarious, which are not bound by
performance of gdbserver, however still better to make it optimized, as
there could be some corner cases where it will help.

Another part of this patch is to properly use CFLAGS_FOR_TARGET. For some
reason we've been using values of CFLAGS when building gdbserver, instead of a proper
environment variable. This value also was coming before our forced CFLAGS:
-O3 -static etc. So our flags have been overriding user settings. This patch
moves reference to CFLAGS_FOR_TARGET to the end of CFLAGS definition, so
user can actually override our flags.

Signed-off-by: Anton Kolesov anton.kolesov@synopsys.com
