### PR TITLE
Add option to enable TLS build.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2015-01-27  Andrew Burgess  <andrew.burgess@embecosm.com>
+
+	* build-all.sh: Add tls command line flags, and set TLS_SUPPORT
+	environment variable.
+	* build-uclibc.sh: Check TLS_SUPPORT environment variable to
+	control thread and tls support features.
+
 2015-01-22  Andrew Burgess  <andrew.burgess@embecosm.com>
 
 	* run-tests.sh: Remove typo from comment and help text.

--- a/build-all.sh
+++ b/build-all.sh
@@ -48,6 +48,7 @@
 #                  [--disable-werror | --no-disable-werror]
 #                  [--strip | --no-strip]
 #                  [--release-name <release>]
+#                  [--tls | --no-tls]
 
 # This script is a convenience wrapper to build the ARC GNU 4.4 tool
 # chains. It utilizes Joern Rennecke's build-elf32.sh script and Bendan
@@ -250,6 +251,12 @@
 #     the gcc repository. If build is done from the source tarball, then
 #     current date is used.
 
+# --tls | --no-tls
+
+#     When building with tls support the uClibc tool chain will
+#     support threading and thread local storage (TLS).
+#     (default --no-tls)
+
 # Where directories are specified as arguments, they are relative to the
 # current directory, unless specified as absolute names.
 
@@ -322,6 +329,7 @@ HOST_INSTALL=install
 SED=sed
 RELEASE_NAME=
 is_tarball=
+TLS_SUPPORT="no"
 
 # Default multilib usage and conversion for toolchain building
 case "x${DISABLE_MULTILIB}" in
@@ -515,6 +523,13 @@ case ${opt} in
 	RELEASE_NAME="$1"
 	;;
 
+    --tls)
+        TLS_SUPPORT="yes"
+        ;;
+    --no-tls)
+        TLS_SUPPORT="no"
+        ;;
+
     ?*)
 	echo "Unknown argument $1"
 	echo
@@ -546,6 +561,7 @@ case ${opt} in
 	echo "                      [--strip | --no-strip]"
 	echo "                      [--sed-tool <tool>]"
 	echo "                      [--release-name <release>]"
+	echo "                      [--tls | --no-tls]"
 	exit 1
 	;;
 
@@ -718,6 +734,7 @@ then
 fi
 export SED
 export RELEASE_NAME
+export TLS_SUPPORT
 
 # Set up a logfile
 logfile="${LOGDIR}/all-build-$(date -u +%F-%H%M).log"

--- a/build-uclibc.sh
+++ b/build-uclibc.sh
@@ -103,6 +103,11 @@
 #     Make target prefix to install host application. Should be either
 #     "install" or "install-strip".
 
+# TLS_SUPPORT
+
+#     Build with threading and thread local storage support if this is
+#     set to "yes".
+
 # Unlike earlier versions of this script, we do not recognize the
 # ARC_GNU_ONLY_CONFIGURE and ARC_GNU_CONTINUE environment variables. If you
 # are using this script, you need to run the whole thing. If you want to redo
@@ -339,13 +344,19 @@ cd "${build_dir_stage1}"
 # Configure the build. Disable anything that might try to build a run-time
 # library and don't bother with multilib for stage 1. Note: with gcc 4.4.x, we
 # also disable building libgomp
+if [ "x${TLS_SUPPORT}" = "xyes" ]
+then
+    thread_flags="--enable-threads --enable-tls"
+else
+    thread_flags="--disable-threads --disable-tls"
+fi
 config_path=$(calcConfigPath "${unified_src_abs}")
 if "${config_path}"/configure --target=${triplet} \
         --with-cpu=${ISA_CPU} \
         --disable-fast-install --with-endian=${ARC_ENDIAN} ${DISABLEWERROR} \
         --disable-multilib \
         --enable-languages=c --prefix="${INSTALLDIR}" \
-        --without-headers --enable-shared --disable-threads --disable-tls \
+        --without-headers --enable-shared ${thread_flags} \
         --disable-libssp --disable-libmudflap --without-newlib --disable-c99 \
         --disable-libgomp ${CONFIG_EXTRA} \
         --with-sysroot=${SYSROOTDIR} \


### PR DESCRIPTION
Adds a new flag (--with-tls) to the build-all.sh script that enables TLS support.  As TLS support has not yet been merged into the binutils / GCC repositories then the default is for TLS support to be turned off.

I've tested building the standard dev branches, and the TLS branches, and everything looks fine to me.  Is there any concerns with merging this now?
