### PR TITLE
Use correct target triplet when looking for libstdc++ results.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-02-17  Andrew Burgess  <andrew.burgess@embecosm.com>
+
+	* run-uclibc-tests.sh: Switch to arc-snps-linux-uclibc target
+	triplet when looking for results.
+
 2015-01-27  Andrew Burgess  <andrew.burgess@embecosm.com>
 
 	* build-all.sh: Add tls command line flags, and set TLS_SUPPORT

--- a/run-uclibc-tests.sh
+++ b/run-uclibc-tests.sh
@@ -106,10 +106,10 @@ readme=${res_uclibc}/README
 if [ "${ARC_ENDIAN}" = "little" ]
 then
     bd_uclibc=${ARC_GNU}/bd-${RELEASE}-uclibc
-    target_dir=arc-linux-uclibc
+    target_dir=arc-snps-linux-uclibc
 else
     bd_uclibc=${ARC_GNU}/bd-${RELEASE}-uclibceb
-    target_dir=arceb-linux-uclibc
+    target_dir=arceb-snps-linux-uclibc
 fi
 
 # Create a file of start up commands for GDB


### PR DESCRIPTION
The target triplet used when building libstdc++ (and libgcc) changed a while back (2da1f4ced48), however, the code to find the results was not updated.  This patch updates the path used when looking for the results.    
