### PR TITLE
uClibc-build.sh: Support for TLS builds

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-02-24  Andrew Burgess  <andrew.burgess@embecosm.com>
+
+	* build-uclibc.sh: Switch on UCLIBC_HAS_THREADS_NATIVE and turn
+	off LINUXTHREADS_OLD when building with TLS support.
+
 2015-02-20  Andrew Burgess  <andrew.burgess@embecosm.com>
 
 	* build-uclibc.sh: Create a temporary defconfig file, edit the

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2015-02-19  Andrew Burgess  <andrew.burgess@embecosm.com>
+
+	* build-uclibc.sh: Remove use of arc_config.
+
 2015-02-17  Andrew Burgess  <andrew.burgess@embecosm.com>
 
 	* run-uclibc-tests.sh: Switch to arc-snps-linux-uclibc target

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-02-20  Andrew Burgess  <andrew.burgess@embecosm.com>
+
+	* build-uclibc.sh: Create a temporary defconfig file, edit the
+	temporary file, then create the .config file.
+
 2015-02-19  Andrew Burgess  <andrew.burgess@embecosm.com>
 
 	* build-uclibc.sh: Remove use of arc_config.

--- a/build-uclibc.sh
+++ b/build-uclibc.sh
@@ -315,6 +315,13 @@ else
            -i ${TEMP_DEFCFG}
 fi
 
+# Patch the defconfig for thread support.
+if [ "x${TLS_SUPPORT}" = "xyes" ]
+then
+    ${SED} -e 's@LINUXTHREADS_OLD=y@UCLIBC_HAS_THREADS_NATIVE=y@' \
+           -i ${TEMP_DEFCFG}
+fi
+
 # Create the .config from the temporary defconfig file.
 make ARCH=arc `basename ${TEMP_DEFCFG}` >> "${logfile}" 2>&1
 
@@ -437,6 +444,13 @@ then
            -i ${TEMP_DEFCFG}
 else
     ${SED} -e 's@ARCH_WANTS_BIG_ENDIAN=y@ARCH_WANTS_LITTLE_ENDIAN=y@' \
+           -i ${TEMP_DEFCFG}
+fi
+
+# Patch the defconfig for thread support.
+if [ "x${TLS_SUPPORT}" = "xyes" ]
+then
+    ${SED} -e 's@LINUXTHREADS_OLD=y@UCLIBC_HAS_THREADS_NATIVE=y@' \
            -i ${TEMP_DEFCFG}
 fi
 


### PR DESCRIPTION
This series of commits does the following:
- The first commit removes what I believe is legacy code.  As far as I can tell we would always be using the defconfig mechanism for configuring uClibc.  The old mechanism, maintaining a pre-made `.config` file, should probably be removed.
- Currently we generate a `.config` file then patch in some customisation changes.  It would be better to patch changes into the defconfig file then generate the `.config`, this would ensure that all dependency resolution that is performed as part of the `.config` generation will see the real values we plan to build with.  This is the second patch.
- The third patch adds changes to turn on native threads when we build with tls support.
