### PR TITLE
Provide a local version of mktemp.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-02-26  Andrew Burgess  <andrew.burgess@embecosm.com>
+
+	* arc-init.sh (temp_file_in_dir): New function.
+	* build-uclibc.sh: Use temp_file_in_dir instead of mktemp.
+
 2015-02-24  Andrew Burgess  <andrew.burgess@embecosm.com>
 
 	* build-uclibc.sh: Switch on UCLIBC_HAS_THREADS_NATIVE and turn

--- a/arc-init.sh
+++ b/arc-init.sh
@@ -158,7 +158,28 @@ save_res () {
 	return  1
     fi
 }
-    
+
+# Some targets have a version of mktemp that does not support the
+# --tmpdir option for creating temporary files in a particular
+# directory.  This wrapper takes a first argument a directory to
+# create the temporary file in, and a second argument the pattern to
+# pass to mktemp.  The function writes out the name of the newly
+# created temporary file, including directory prefix, and the return
+# value will be zero on success, otherwise non-zero on error.
+temp_file_in_dir () {
+    DIR=$1
+    PATTERN=$2
+    FILE=$(cd ${DIR} && mktemp "${PATTERN}")
+    STATUS=$?
+    if [ ${STATUS} == 0 ]
+    then
+        echo ${DIR}/${FILE}
+    else
+        echo "temp_file failed: ${FILE}"
+    fi
+    return ${STATUS}
+}
+
 # Make sure we stop if something failed. Since we are run with source, not exec
 # the build=*.sh scripts will also do this.
 trap "echo ERROR: Failed due to signal ; date ; exit 1" \

--- a/build-uclibc.sh
+++ b/build-uclibc.sh
@@ -290,7 +290,7 @@ fi
 make distclean >> "${logfile}" 2>&1 || true 
 
 # Copy the defconfig file to a temporary location
-TEMP_DEFCFG=`mktemp --tmpdir=${DEFCFG_DIR} XXXXXXXXXX_defconfig`
+TEMP_DEFCFG=`temp_file_in_dir "${DEFCFG_DIR}" XXXXXXXXXX_defconfig`
 if [ ! -f "${TEMP_DEFCFG}" ]
 then
     echo "ERROR: Failed to create temporary defconfig file."
@@ -418,7 +418,7 @@ echo "Start building UCLIBC ..."
 cd ${uclibc_build_dir}
 
 # Copy the defconfig file to a temporary location
-TEMP_DEFCFG=`mktemp --tmpdir=${DEFCFG_DIR} XXXXXXXXXX_defconfig`
+TEMP_DEFCFG=`temp_file_in_dir "${DEFCFG_DIR}" XXXXXXXXXX_defconfig`
 if [ ! -f "${TEMP_DEFCFG}" ]
 then
     echo "ERROR: Failed to create temporary defconfig file."


### PR DESCRIPTION
On some targets (RHEL5) the version of mktemp available does not support the --tmpdir option.  To work around this a local version of mktemp (called temp_file_in_dir) is provided and used.
