### PR TITLE
Mark nsim-gdb board as a simulator

### DIFF
--- a/dejagnu/baseboards/arc-nsim.exp
+++ b/dejagnu/baseboards/arc-nsim.exp
@@ -103,4 +103,8 @@ if { $tool == "gdb" } {
 	set_board_info gdb,nofileio 1
 }
 
+# Tests may recognize this board as a simulator and reduce amount
+# of computations.
+set_board_info is-simulator 1
+
 # vim: noexpandtab sts=4 ts=8:


### PR DESCRIPTION
Thus DejaGnu tests may recognize this board as a simulator
and reduce amount of computations.

Signed-off-by: Yuriy Kolerov yuriy.kolerov@synopsys.com
