### PR TITLE
Build GCC for elf32 in 2 stages to fix providing newlib headers

### DIFF
--- a/arc-init.sh
+++ b/arc-init.sh
@@ -341,7 +341,6 @@ configure_elf32() {
 	$DISABLEWERROR \
 	--enable-languages=c,c++ \
 	--prefix="$INSTALLDIR" \
-	--with-headers="$ARC_GNU/newlib/newlib/libc/include" \
 	$host_opt \
 	$sim_config \
 	$CONFIG_EXTRA \


### PR DESCRIPTION
GCC must be built in 2 stages. First minimal GCC build is for building newlib and second stage is a complete GCC with newlib headers. See: http://www.ifp.illinois.edu/~nakazato/tips/xgcc.html

Moreover it's no longer needed to replace "sys-include" by "include" in the install directory because with this 2 stage building only "include" with valid target specific headers is generated.
