### PR TITLE
Turn on timers support for nsim baseboard

### DIFF
--- a/dejagnu/baseboards/arc-sim-nsimdrv.exp
+++ b/dejagnu/baseboards/arc-sim-nsimdrv.exp
@@ -33,7 +33,8 @@ load_base_board_description "basic-sim"
 set multilib_opts "$env(ARC_MULTILIB_OPTIONS)"
 process_multilib_options "$multilib_opts"
 
-set xldflags "-Wl,--defsym=__DEFAULT_HEAP_SIZE=256m -Wl,--defsym=__DEFAULT_STACK_SIZE=1024m"
+set xldflags "-Wl,--defsym=__DEFAULT_HEAP_SIZE=256m \
+    -Wl,--defsym=__DEFAULT_STACK_SIZE=1024m"
 
 # Set common defaults
 set xarchflags "-on nsim_isa_spfp -on nsim_isa_dpfp -on nsim_isa_atomic_option \
@@ -41,7 +42,8 @@ set xarchflags "-on nsim_isa_spfp -on nsim_isa_dpfp -on nsim_isa_atomic_option \
 
 # Hostlink library support
 if { [ info exists env(ARC_HOSTLINK_LIBRARY) ] } {
-    set xldflags "$xldflags -Wl,--whole-archive $env(ARC_HOSTLINK_LIBRARY) -Wl,--no-whole-archive"
+    set xldflags "$xldflags -Wl,--whole-archive $env(ARC_HOSTLINK_LIBRARY) \
+        -Wl,--no-whole-archive"
 } else {
     # Use nSIM GNU IO hostlink, instead of MetaWare compatible one
     set xarchflags "$xarchflags -on nsim_emt"
@@ -54,13 +56,18 @@ if [ string match arceb-* $target_triplet ] {
 
 # ARC EM is default
 if { [string first arc700 "$multilib_opts"] == 0 } {
-    set xarchflags "$xarchflags -p nsim_isa_family=a700 -on nsim_isa_sat -on nsim_isa_mpy32"
+    set xarchflags "$xarchflags -p nsim_isa_family=a700 -on nsim_isa_sat \
+        -on nsim_isa_mpy32"
 } elseif { [string first arc600 "$multilib_opts"] == 0 } {
-    set xarchflags "$xarchflags -p nsim_isa_family=a600 -p nsim_isa_core=6 -on nsim_isa_sat -on nsim_isa_mult32"
+    set xarchflags "$xarchflags -p nsim_isa_family=a600 -p nsim_isa_core=6 \
+        -on nsim_isa_sat -on nsim_isa_mult32"
 } elseif { [string first archs "$multilib_opts"] == 0 } {
-    set xarchflags "$xarchflags -p nsim_isa_family=av2hs -p nsim_isa_core=1 -on nsim_isa_ll64_option -p nsim_isa_mpy_option=9 -p nsim_isa_div_rem_option=2 -on nsim_isa_sat"
+    set xarchflags "$xarchflags -p nsim_isa_family=av2hs -p nsim_isa_core=1 \
+        -on nsim_isa_ll64_option -p nsim_isa_mpy_option=9 \
+        -p nsim_isa_div_rem_option=2 -on nsim_isa_sat"
 } else {
-    set xarchflags "$xarchflags -p nsim_isa_family=av2em -p nsim_isa_core=1 -p nsim_isa_mpy_option=9 -p nsim_isa_div_rem_option=2 -on nsim_isa_sat"
+    set xarchflags "$xarchflags -p nsim_isa_family=av2em -p nsim_isa_core=1 \
+        -p nsim_isa_mpy_option=9 -p nsim_isa_div_rem_option=2 -on nsim_isa_sat"
 }
 
 # Allow user to specify additional options, like JIT, etc.

--- a/dejagnu/baseboards/arc-sim-nsimdrv.exp
+++ b/dejagnu/baseboards/arc-sim-nsimdrv.exp
@@ -36,7 +36,8 @@ process_multilib_options "$multilib_opts"
 set xldflags "-Wl,--defsym=__DEFAULT_HEAP_SIZE=256m -Wl,--defsym=__DEFAULT_STACK_SIZE=1024m"
 
 # Set common defaults
-set xarchflags "-on nsim_isa_spfp -on nsim_isa_dpfp -on nsim_isa_atomic_option"
+set xarchflags "-on nsim_isa_spfp -on nsim_isa_dpfp -on nsim_isa_atomic_option \
+    -on nsim_isa_enable_timer_0 -on nsim_isa_enable_timer_1"
 
 # Hostlink library support
 if { [ info exists env(ARC_HOSTLINK_LIBRARY) ] } {


### PR DESCRIPTION
It's necessary for regression tests with profilers (-p and -pg).
