### PR TITLE
Add options --elf32-gcc-stage1 and --no-elf32-gcc-stage1

### DIFF
--- a/Makefile.release
+++ b/Makefile.release
@@ -219,7 +219,8 @@ $O/.stamp_elf_le_windows_built: $O/.stamp_checked_out $O/.stamp_elf_le_built
 	PATH=$(shell readlink -e $O/$(TOOLS_ELFLE_DIR_LINUX)/bin):$$PATH \
 	     ./build-all.sh $(BUILDALLFLAGS) \
 	     --install-dir $O/$(TOOLS_ELFLE_DIR_WIN) --no-uclibc --no-sim \
-	     --release-name $(RELEASE) --host i686-w64-mingw32 --no-system-expat
+	     --release-name $(RELEASE) --host i686-w64-mingw32 --no-system-expat \
+	     --no-elf32-gcc-stage1
 	touch $@
 
 $O/.stamp_elf_be_windows_built: $O/.stamp_checked_out $O/.stamp_elf_be_built
@@ -227,7 +228,8 @@ $O/.stamp_elf_be_windows_built: $O/.stamp_checked_out $O/.stamp_elf_be_built
 	PATH=$(shell readlink -e $O/$(TOOLS_ELFBE_DIR_LINUX))/bin:$$PATH \
 	     ./build-all.sh $(BUILDALLFLAGS) \
 	     --install-dir $O/$(TOOLS_ELFBE_DIR_WIN) --no-uclibc --big-endian --no-sim \
-	     --release-name $(RELEASE) --host i686-w64-mingw32 --no-system-expat
+	     --release-name $(RELEASE) --host i686-w64-mingw32 --no-system-expat \
+	     --no-elf32-gcc-stage1
 	touch $@
 
 $O/.stamp_elf_le_windows_tarball: $O/.stamp_elf_le_windows_built

--- a/build-all.sh
+++ b/build-all.sh
@@ -52,6 +52,7 @@
 #                  [--host <triplet>]
 #                  [--native-gdb | --no-native-gdb]
 #                  [--system-expat | --no-system-expat]
+#                  [--elf32-gcc-stage1 | --no-elf32-gcc-stage1]
 
 # This script is a convenience wrapper to build the ARC GNU 4.4 tool
 # chains. It utilizes Joern Rennecke's build-elf32.sh script and Bendan
@@ -299,6 +300,13 @@
 #    version. Notable use case for --no-system-expat is mingw32 build, if mingw
 #    installation lacks expat. Default value is to use system expat.
 
+# --elf32-gcc-stage1 | --no-elf32-gcc-stage1
+
+#     Whether to build or not to build gcc-stage1 for elf32 targets. It may
+#     may be useful to turn off building gcc-stage1 if toolchain is already
+#     presented in PATH thus newlib may be built by precompiled GCC. Default
+#     is --elf32-gcc-stage1.
+
 # Where directories are specified as arguments, they are relative to the
 # current directory, unless specified as absolute names.
 
@@ -375,6 +383,7 @@ NPTL_SUPPORT="yes"
 CHECKOUT_CONFIG=
 TOOLCHAIN_HOST=
 SYSTEM_EXPAT=yes
+DO_ELF32_GCC_STAGE1=yes
 
 # Default multilib usage and conversion for toolchain building
 case "x${DISABLE_MULTILIB}" in
@@ -597,6 +606,14 @@ case ${opt} in
 	SYSTEM_EXPAT=no
 	;;
 
+    --elf32-gcc-stage1)
+	DO_ELF32_GCC_STAGE1=yes
+	;;
+
+    --no-elf32-gcc-stage1)
+	DO_ELF32_GCC_STAGE1=no
+	;;
+
     ?*)
 	echo "Unknown argument $1"
 	echo
@@ -632,6 +649,7 @@ case ${opt} in
 	echo "                      [--host <triplet>]"
 	echo "                      [--native-gdb | --no-native-gdb]"
 	echo "                      [--system-expat | --no-system-expat]"
+	echo "                      [--elf32-gcc-stage1 | --no-elf32-gcc-stage1]"
 	exit 1
 	;;
 
@@ -817,6 +835,7 @@ export CHECKOUT_CONFIG
 export TOOLCHAIN_HOST
 export UCLIBC_TOOLS_VERSION
 export SYSTEM_EXPAT
+export DO_ELF32_GCC_STAGE1
 
 # Set up a logfile
 logfile="${LOGDIR}/all-build-$(date -u +%F-%H%M).log"

--- a/build-elf32.sh
+++ b/build-elf32.sh
@@ -222,10 +222,12 @@ fi
 # GCC must be built in 2 stages. First minimal GCC build is for building
 # newlib and second stage is a complete GCC with newlib headers. See:
 # http://www.ifp.illinois.edu/~nakazato/tips/xgcc.html
-build_dir_init gcc-stage1
-configure_elf32 gcc gcc --without-headers --with-newlib
-make_target building all-gcc
-make_target installing ${HOST_INSTALL}-gcc
+if [ "$DO_ELF32_GCC_STAGE1" = "yes" ]; then
+    build_dir_init gcc-stage1
+    configure_elf32 gcc gcc --without-headers --with-newlib
+    make_target building all-gcc
+    make_target installing ${HOST_INSTALL}-gcc
+fi
 
 # Newlib (build in sub-shell with new tools added to the PATH)
 build_dir_init newlib


### PR DESCRIPTION
Whether to build or not to build gcc-stage1 for elf32 targets. It may
may be useful to turn off building gcc-stage1 if toolchain is already
presented in PATH thus newlib may be built by precompiled GCC. Default
is --elf32-gcc-stage1.
