### PR TITLE
Enter correct directory to run tests.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2015-10-26  Andrew Burgess  <andrew.burgess@embecosm.com>
+
+	* run-elf32-tests.sh: Use gcc-stage2 directory for gcc related
+	testing.
+	* run-uclibc-tests.sh: Use correct directory for running all
+	tests.
+
 2015-02-27  Anton Kolesov  <Anton.Kolesov@synopsys.com>
 
 	* tag-releas.sh: Tag Linux repository.

--- a/run-elf32-tests.sh
+++ b/run-elf32-tests.sh
@@ -157,19 +157,19 @@ fi
 # gcc and g++
 if [ "x${DO_GCC}" = "xyes" ]
 then
-    run_check ${bd_elf}/gcc \
+    run_check ${bd_elf}/gcc-stage2 \
 	gcc \
 	"${logfile_elf}" \
 	${ARC_TEST_BOARD_ELF32} \
 	|| status=1
     save_res \
-	${bd_elf}/gcc \
+	${bd_elf}/gcc-stage2 \
 	${res_elf} \
 	gcc/testsuite/gcc/gcc \
 	"${logfile_elf}" \
 	|| status=1
     echo "Testing g++..."
-    save_res ${bd_elf}/gcc \
+    save_res ${bd_elf}/gcc-stage2 \
 	${res_elf} \
 	gcc/testsuite/g++/g++ \
 	"${logfile_elf}" \
@@ -178,12 +178,12 @@ fi
 # libgcc
 if [ "x${DO_LIBGCC}" = "xyes" ]
 then
-    run_check ${bd_elf}/gcc \
+    run_check ${bd_elf}/gcc-stage2 \
 	target-libgcc \
 	"${logfile_elf}" \
 	${ARC_TEST_BOARD_ELF32} \
 	|| status=1
-    save_res ${bd_elf}/gcc \
+    save_res ${bd_elf}/gcc-stage2 \
 	${res_elf} \
 	${target_dir}/libgcc/testsuite/libgcc \
 	"${logfile_elf}" \
@@ -220,12 +220,12 @@ fi
 # libstdc++
 if [ "x${DO_LIBSTDCPP}" = "xyes" ]
 then
-    run_check ${bd_elf}/gcc \
+    run_check ${bd_elf}/gcc-stage2 \
 	target-libstdc++-v3 \
 	"${logfile_elf}" \
 	${ARC_TEST_BOARD_ELF32} \
 	|| status=1
-    save_res ${bd_elf}/gcc \
+    save_res ${bd_elf}/gcc-stage2 \
 	${res_elf} \
 	${target_dir}/libstdc++-v3/testsuite/libstdc++ \
 	"${logfile_elf}" \

--- a/run-uclibc-tests.sh
+++ b/run-uclibc-tests.sh
@@ -123,12 +123,12 @@ status=0
 # binutils
 if [ "x${DO_BINUTILS}" = "xyes" ]
 then
-    run_check ${bd_uclibc} \
+    run_check ${bd_uclibc}/binutils \
 	binutils \
 	"${logfile_uclibc}" \
 	${ARC_TEST_BOARD_UCLIBC} \
 	|| status=1
-    save_res  ${bd_uclibc} \
+    save_res  ${bd_uclibc}/binutils \
 	${res_uclibc} \
 	binutils/binutils \
 	"${logfile_uclibc}" \
@@ -137,11 +137,11 @@ fi
 # gas
 if [ "x${DO_GAS}" = "xyes" ]
 then
-    run_check ${bd_uclibc} \
+    run_check ${bd_uclibc}/binutils \
 	gas "${logfile_uclibc}" \
 	${ARC_TEST_BOARD_UCLIBC} \
 	|| status=1
-    save_res  ${bd_uclibc} \
+    save_res  ${bd_uclibc}/binutils \
 	${res_uclibc} \
 	gas/testsuite/gas \
 	"${logfile_uclibc}" \
@@ -150,11 +150,11 @@ fi
 # ld
 if [ "x${DO_LD}" = "xyes" ]
 then
-    run_check ${bd_uclibc} \
+    run_check ${bd_uclibc}/binutils \
 	ld "${logfile_uclibc}" \
 	${ARC_TEST_BOARD_UCLIBC} \
 	|| status=1
-    save_res  ${bd_uclibc} \
+    save_res  ${bd_uclibc}/binutils \
 	${res_uclibc} \
 	ld/ld \
 	"${logfile_uclibc}" \
@@ -163,18 +163,18 @@ fi
 # gcc and g++
 if [ "x${DO_GCC}" = "xyes" ]
 then
-    run_check ${bd_uclibc} \
+    run_check ${bd_uclibc}/gcc-stage2 \
 	gcc \
 	"${logfile_uclibc}" \
 	${ARC_TEST_BOARD_UCLIBC} \
 	|| status=1
-    save_res  ${bd_uclibc} \
+    save_res  ${bd_uclibc}/gcc-stage2 \
 	${res_uclibc} \
 	gcc/testsuite/gcc/gcc \
 	"${logfile_uclibc}" \
 	|| status=1
     echo "Testing g++..."
-    save_res  ${bd_uclibc} \
+    save_res  ${bd_uclibc}/gcc-stage2 \
 	${res_uclibc} \
 	gcc/testsuite/g++/g++ \
 	"${logfile_uclibc}" \
@@ -183,12 +183,12 @@ fi
 # libgcc
 if [ "x${DO_LIBGCC}" = "xyes" ]
 then
-    run_check ${bd_uclibc} \
+    run_check ${bd_uclibc}/gcc-stage2 \
 	target-libgcc \
 	"${logfile_uclibc}" \
 	${ARC_TEST_BOARD_UCLIBC} \
 	|| status=1
-    save_res ${bd_uclibc} \
+    save_res ${bd_uclibc}/gcc-stage2 \
 	${res_uclibc} \
 	${target_dir}/libgcc/testsuite/libgcc \
 	"${logfile_uclibc}" \
@@ -197,12 +197,12 @@ fi
 # libstdc++
 if [ "x${DO_LIBSTDCPP}" = "xyes" ]
 then
-    run_check ${bd_uclibc} \
+    run_check ${bd_uclibc}/gcc-stage2 \
 	target-libstdc++-v3 \
 	"${logfile_uclibc}" \
 	${ARC_TEST_BOARD_UCLIBC} \
 	|| status=1
-    save_res  ${bd_uclibc} \
+    save_res  ${bd_uclibc}/gcc-stage2 \
 	${res_uclibc} \
 	${target_dir}/libstdc++-v3/testsuite/libstdc++ \
 	"${logfile_uclibc}" \
@@ -211,11 +211,11 @@ fi
 # gdb
 if [ "x${DO_GDB}" = "xyes" ]
 then
-    run_check ${bd_uclibc} \
+    run_check ${bd_uclibc}/gdb \
 	gdb "${logfile_uclibc}" \
 	${ARC_TEST_BOARD_UCLIBC} \
 	|| status=1
-    save_res  ${bd_uclibc} \
+    save_res  ${bd_uclibc}/gdb \
 	${res_uclibc} \
 	gdb/testsuite/gdb \
 	"${logfile_uclibc}" \


### PR DESCRIPTION
For the elf32 tests the wrong directory was being used to run the GCC
tests, update the directory used to run all the GCC related elf32
tests.

For uClibc, the wrong directories were being used for all testing,
update all directory names.

Change Log:

```
* run-elf32-tests.sh: Use gcc-stage2 directory for gcc related
testing.
* run-uclibc-tests.sh: Use correct directory for running all
tests.
```
