### PR TITLE
Smartly detect for which ARC processor we simulate using the compiler…

### DIFF
--- a/dejagnu/baseboards/arc-sim-nsimdrv.exp
+++ b/dejagnu/baseboards/arc-sim-nsimdrv.exp
@@ -30,8 +30,15 @@ load_generic_config "sim"
 load_base_board_description "basic-sim"
 
 # Any multilib options are set in an environment variable.
-set multilib_opts "$env(ARC_MULTILIB_OPTIONS)"
+if { [ info exists env(ARC_MULTILIB_OPTIONS) ] } {
+    set multilib_opts "$env(ARC_MULTILIB_OPTIONS)"
+} else {
+    set multilib_opts ""
+}
 process_multilib_options "$multilib_opts"
+
+# We need extra procedures to determine for which cpu we simulate.
+search_and_load_file "library file" "tool-extra.exp" ${boards_dir}
 
 set xldflags "-Wl,--defsym=__DEFAULT_HEAP_SIZE=256m \
     -Wl,--defsym=__DEFAULT_STACK_SIZE=1024m"
@@ -108,33 +115,36 @@ if [ string match arceb-* $target_triplet ] {
     lappend nsim_flags -on nsim_isa_big_endian
 }
 
-# ARC EM is default
-if { [string first arc700 "$multilib_opts"] == 0 } {
+if { [check_target_arc700] } {
     lappend nsim_flags \
-	    -p nsim_isa_family=a700 \
-	    -on nsim_isa_sat \
-	    -on nsim_isa_mpy32
-} elseif { [string first arc600 "$multilib_opts"] == 0 } {
+	-p nsim_isa_family=a700 \
+	-on nsim_isa_sat \
+	-on nsim_isa_mpy32
+} elseif { [check_target_arc6xx] } {
     lappend nsim_flags \
-	    -p nsim_isa_family=a600 \
-	    -p nsim_isa_core=6 \
-	    -on nsim_isa_sat \
-	    -on nsim_isa_mult32
-} elseif { [string first archs "$multilib_opts"] == 0 } {
+	-p nsim_isa_family=a600 \
+	-p nsim_isa_core=6 \
+	-on nsim_isa_sat \
+	-on nsim_isa_mult32
+} elseif { [check_target_archs] } {
     lappend nsim_flags \
-	    -p nsim_isa_family=av2hs \
-	    -p nsim_isa_core=1 \
-	    -on nsim_isa_ll64_option \
-	    -p nsim_isa_mpy_option=9 \
-	    -p nsim_isa_div_rem_option=2 \
-	    -on nsim_isa_sat
+	-p nsim_isa_family=av2hs \
+	-p nsim_isa_core=1 \
+	-on nsim_isa_ll64_option \
+	-p nsim_isa_mpy_option=9 \
+	-p nsim_isa_div_rem_option=2 \
+	-on nsim_isa_sat
+} elseif { [check_target_arcem] } {
+    lappend nsim_flags \
+	-p nsim_isa_family=av2em \
+	-p nsim_isa_core=1 \
+	-p nsim_isa_mpy_option=9 \
+	-p nsim_isa_div_rem_option=2 \
+	-on nsim_isa_sat \
+	-p nsim_isa_code_density_option=2 \
+	-p nsim_isa_fpus_option=1
 } else {
-    lappend nsim_flags \
-	    -p nsim_isa_family=av2em \
-	    -p nsim_isa_core=1 \
-	    -p nsim_isa_mpy_option=9 \
-	    -p nsim_isa_div_rem_option=2 \
-	    -on nsim_isa_sat
+    perror "Unknown CPU configuration"
 }
 
 # Allow user to specify additional options, like JIT, etc.

--- a/dejagnu/tool-extra.exp
+++ b/dejagnu/tool-extra.exp
@@ -1,0 +1,62 @@
+proc check_target_arc { arg } {
+    global target_alias
+    global board
+    global board_info
+
+    if {[info exists board]} {
+	set target_board $board
+    } else {
+	set target_board [target_info name]
+    }
+
+    if { [board_info $target_board exists compiler] } {
+	set compiler [board_info $target_board compiler]
+    } else {
+	set compiler [find_gcc]
+    }
+
+    if { $compiler == "" } {
+	return ""
+    }
+
+    regexp "/.* " $compiler compiler
+    set compiler [string trimright $compiler " "]
+    verbose "compiler is $compiler"
+
+    if { [which $compiler] == 0 } {
+	return ""
+    }
+
+    if { [board_info $target_board exists multilib_flags] } {
+	set opts [board_info $target_board multilib_flags]
+    } else {
+	set opts ""
+    }
+
+    set result [eval exec $compiler $opts -dM -E - < /dev/null]
+    verbose "Default defines : $result"
+    return [regexp "$arg" "$result"]
+}
+
+proc check_target_archs { } {
+    return [check_target_arc "__ARCHS__"]
+}
+
+# Return 1 if this is a compiler supporting ARCv2 EM as default processor
+proc check_target_arcem { } {
+    return [check_target_arc "__ARCEM__"]
+}
+
+# Return 1 if we compile for ARC700
+proc check_target_arc700 { } {
+    return [check_target_arc "__ARC700__"]
+}
+
+# Return 1 if we compile for ARC6xx
+proc check_target_arc6xx { } {
+    if { [check_target_arc "__ARC600__"]
+	 || [check_target_arc "__ARC601__"] } {
+	return 1
+    }
+    return 0
+}


### PR DESCRIPTION
… macros.

This patch renders absolete the requirements of having the environment
variable ARC_MULTILIB_OPTIONS defined. Thus, when it is not defined,
the default procesor will be used. The default processor is given by
--with-cpu flag passed to the configure script when we build the
compiler.

The simulator parameters are set by procedures that are checking the
gcc default defines. Hence, regardless of the mcpu option, we will get
the correct ARC family. The mcpu option will be changed to hold
multiple cpu templates (e.g. mcpu=em4).

2016-01-08  Claudiu Zissulescu  claziss@synopsys.com

```
* dejagnu/baseboards/arc-sim-nsimdrv.exp: Select simulation
options based on the gcc macros.
* dejagnu/tool-extra.exp: New file.
```
