### PR TITLE
Use pv command to visualise the progress of the installation

### DIFF
--- a/arc-init.sh
+++ b/arc-init.sh
@@ -540,7 +540,7 @@ make_target() {
     local step="$1"
     shift
     echo "  $step..."
-    if ! make $PARALLEL $* >> "$logfile" 2>&1
+    if ! make $PARALLEL $* 2>&1 | $PV >> "$logfile"
     then
 	echo "ERROR: failed while $step."
 	echo "See \`$logfile' for details."
@@ -557,7 +557,7 @@ make_target_ordered() {
     local step="$1"
     shift
     echo "  $step..."
-    if ! make $* >> "$logfile" 2>&1
+    if ! make $*  2>&1 | $PV >> "$logfile"
     then
 	echo "ERROR: failed while $step."
 	echo "See \`$logfile' for details."

--- a/build-all.sh
+++ b/build-all.sh
@@ -888,6 +888,13 @@ if [ -z "$WGET" ]; then
     export WGET
 fi
 
+if hash pv 2>/dev/null; then
+    PV='pv -p --timer'
+else
+    PV='tee'
+fi
+export PV
+
 # Standard setup
 . "${ARC_GNU}/toolchain/arc-init.sh"
 


### PR DESCRIPTION
The pv command is using the log file and it will give a feedback to the builder that the process is still running. It also useful for other integration tools which are checking for the terminal activities.
