### PR TITLE
Add support of compat.exp tests from GCC testsuite

### DIFF
--- a/dejagnu/baseboards/arc-nsim.exp
+++ b/dejagnu/baseboards/arc-nsim.exp
@@ -42,6 +42,10 @@ load_generic_config "gdb-comm"
 # overrides one of the function in gdb-comm.
 search_and_load_file "library file" "nsim-extra.exp" ${boards_dir}
 
+# Load procedures for enabling support of compatibility tests (compat.exp
+# from GCC testsuite).
+search_and_load_file "library file" "tool-extra.exp" ${boards_dir}
+
 # GDB tests require special treatment, they ignore "gdb-comm" configuration
 # unless "monitor" GDB test suite configuration is loaded.
 if { $tool == "gdb" } {
@@ -161,5 +165,19 @@ if { $tool == "gdb" } {
 # Tests may recognize this board as a simulator and reduce amount
 # of computations.
 set_board_info is_simulator 1
+
+# Turn on support of compat.exp tests from GCC testsuite if environment
+# variable ARC_GCC_COMPAT_SUITE == 1.
+if { [info exists env(ARC_GCC_COMPAT_SUITE)] } {
+    set is_gcc_compat_suite $env(ARC_GCC_COMPAT_SUITE)
+} else {
+    if { ![info exists is_gcc_compat_suite] } {
+	set is_gcc_compat_suite 0
+    }
+}
+
+if { $is_gcc_compat_suite } {
+    fix_gcc_compat_multilib_flags
+}
 
 # vim: noexpandtab sts=4 ts=8:

--- a/dejagnu/baseboards/arc-sim-nsimdrv.exp
+++ b/dejagnu/baseboards/arc-sim-nsimdrv.exp
@@ -232,4 +232,18 @@ set_board_info gdb,nosignals 1
 set_board_info gdb,noresults 1
 set_board_info gdb,noinferiorio 1
 
+# Turn on support of compat.exp tests from GCC testsuite if environment
+# variable ARC_GCC_COMPAT_SUITE == 1.
+if { [info exists env(ARC_GCC_COMPAT_SUITE)] } {
+    set is_gcc_compat_suite $env(ARC_GCC_COMPAT_SUITE)
+} else {
+    if { ![info exists is_gcc_compat_suite] } {
+	set is_gcc_compat_suite 0
+    }
+}
+
+if { $is_gcc_compat_suite } {
+    fix_gcc_compat_multilib_flags
+}
+
 # vim: noexpandtab sts=4 ts=8:

--- a/dejagnu/example_run.sh
+++ b/dejagnu/example_run.sh
@@ -42,6 +42,33 @@
 # TODO: Better to use TCFs...
 # nsim_props_root = SET ME
 
+# Set to run specific DejaGnu tests. Example:
+# runtestflags="suite-name.exp=test-name.c"
+runtestflags=""
+
+# Enable support of compat.exp tests from GCC testsuite if necessary.
+# These tests are intended to check compatibility between GNU and MetaWare
+# compilers. There is an example of configuration for ARC EM (little endian).
+export ARC_GCC_COMPAT_SUITE="0"
+
+if [ "${ARC_GCC_COMPAT_SUITE:-0}" == "1" ]; then
+    runtestflags="compat.exp"
+
+    # Set path to alternate compiler.
+    export GCC_COMPAT_CCAC_PATH="$METAWARE_ROOT/arc/bin/ccac"
+
+    # Set options for GCC. If you want to run tests for big endian target
+    # it's necessary to pass "-EB" to MetaWare compiler and change path to
+    # MetaWare libraries from "-L$METAWARE_HOME/arc/lib/av2em/le" to
+    # "-L$METAWARE_HOME/arc/lib/av2em/be".
+    export GCC_COMPAT_GCC_OPTIONS="-O0 -g -mcpu=arcem -mno-sdata -mabi=mwabi \
+        -fshort-enums -Wl,-z,muldefs -Wl,--no-warn-mismatch -lgcc -lnsim -lc \
+        -lg -lm -L$METAWARE_ROOT/arc/lib/av2em/le -lmw"
+
+    # Set options for alternate compiler.
+    export GCC_COMPAT_CCAC_OPTIONS="-O0 -g -av2em -Xbasecase -Hnocopyr -Hnosdata"
+fi
+
 #
 # Run
 #
@@ -78,4 +105,4 @@ case $tool in
 	cp -a $tools_installation/$triplet/include/newlib.h targ-include
 esac
 
-runtest --tool=$tool --target_board=$board --target=arc-default-elf32
+runtest --tool=$tool --target_board=$board --target=arc-default-elf32 $runtestflags

--- a/dejagnu/example_site.exp
+++ b/dejagnu/example_site.exp
@@ -71,3 +71,20 @@ switch $tool {
 	}
     }
 }
+
+if { [info exists env(ARC_GCC_COMPAT_SUITE)] } {
+    set is_gcc_compat_suite "$env(ARC_GCC_COMPAT_SUITE)"
+} else {
+    set is_gcc_compat_suite "0"
+}
+
+# Configure DejaGnu for testing compatibility between GNU and MetaWare compilers.
+if { $is_gcc_compat_suite == "1" } {
+    set ALT_CC_UNDER_TEST	"$env(GCC_COMPAT_CCAC_PATH)"
+    set ALT_CXX_UNDER_TEST	"$ALT_CC_UNDER_TEST"
+    set COMPAT_OPTIONS		[list [list "$env(GCC_COMPAT_GCC_OPTIONS)" "$env(GCC_COMPAT_CCAC_OPTIONS)"]]
+    # Disable tests with packed structures to avoid unaligned access errors.
+    set COMPAT_SKIPS		[list {ATTRIBUTE}]
+}
+
+# vim: noexpandtab sts=4 ts=8:

--- a/dejagnu/tool-extra.exp
+++ b/dejagnu/tool-extra.exp
@@ -88,3 +88,45 @@ proc check_target_arc600 { } {
 proc check_target_arc601 { } {
     return [check_target_arc "__ARC601__"]
 }
+
+# Fix multilib flags for compat.exp tests of GCC testsuite. This function
+# removes all multilib flags from board info and appends them to testglues's
+# flags. It is necessary because compat.exp uses alternate compiler which
+# may not support GCC's multilib flags (they must be passed manually to each
+# compiler). However testglue must be compiled with those multilib flags so
+# this function also appends them to testglue's flags using wrap_compile_flags
+# variable. This function must be called last to let check_target_arc
+# function detect ARC core by multilib flags correctly.
+proc fix_gcc_compat_multilib_flags { } {
+    global board
+    global board_info
+
+    if { [info exists board] } {
+	set target_board $board
+    } else {
+	set target_board [target_info name]
+    }
+
+    # Get multilib flags if they exist.
+    if { [board_info $target_board exists multilib_flags] } {
+	set multilib_flags [board_info $target_board multilib_flags]
+    } else {
+	set multilib_flags ""
+    }
+
+    # Set flags for testglue.
+    set_board_info wrap_compile_flags "$multilib_flags"
+
+    # Erase multilib flags to prevent errors when alternative compiler
+    # is used in compat.exp tests of GCC testsuite.
+    unset_board_info multilib_flags
+    set_board_info multilib_flags ""
+
+    # Tests from compat.exp are short but sometimes some failing tests may
+    # lead to hanging of nSIM. So it is better to set a small time limit for
+    # the simulator.
+    unset_board_info sim_time_limit
+    set_board_info sim_time_limit 30
+}
+
+# vim: noexpandtab sts=4 ts=8:


### PR DESCRIPTION
Add fix_gcc_compat_multilib_flags function which fixes multilib flags for compat.exp tests from GCC testsuite. This function removes all multilib flags from board info and appends them to testglues's flags. It is necessary because compat.exp uses alternate compiler which may not support GCC's multilib flags (they must be passed manually to each compiler). However testglue must be compiled with those multilib flags so this function also appends them to testglue's flags using wrap_compile_flags variable. This function must be called last to let check_target_arc function detect ARC core by multilib flags correctly.
