### PR TITLE
Fix function compile files for quarkse_em

### DIFF
--- a/dejagnu/tool-extra.exp
+++ b/dejagnu/tool-extra.exp
@@ -67,7 +67,8 @@ proc compile_quarkse_em_nsim_apex { } {
     set dir $ARC_NSIM_APEX_DIR
     set files [glob -directory $dir *]
     foreach source $files {
-	regexp "$dir/(.*)\.cpp" $source source filename
+        # File name without directory and expansion.
+	set filename [file rootname [file tail $source]]
 	set dest "$tmpdir/quarkse_em_$filename.so"
 	set cxxflags "-O2 -fPIC -shared -rdynamic"
 	if { [info exists HOSTCXXFLAGS] } {


### PR DESCRIPTION
Delete regular expression from function
compile_quarkse_em_nsim_apex because g++ and libstdc++ tests
didn't run. It was because regular expression take '+' as symbol
for regular expression.
