### PR TITLE
[ARC] Add support for QuarkSE2 EM cpus.

### DIFF
--- a/dejagnu/baseboards/arc-sim-nsimdrv.exp
+++ b/dejagnu/baseboards/arc-sim-nsimdrv.exp
@@ -138,6 +138,16 @@ if { [check_target_arc700] } {
 	-prop=nsim_ext=$tmpdir/quarkse_em_fssqrt.so \
 	-p nsim_isa_spfp=compact \
 	-p nsim_isa_dpfp=compact
+} elseif { [check_target_quarkse2_em] } {
+    compile_quarkse_em_nsim_apex
+    lappend nsim_flags \
+	-p nsim_isa_family=av2em \
+	-p nsim_isa_core=1 \
+	-p nsim_isa_mpy_option=2 \
+	-p nsim_isa_div_rem_option=2 \
+	-p nsim_isa_code_density_option=2 \
+	-prop=nsim_ext=$tmpdir/quarkse_em_fsdiv.so \
+	-prop=nsim_ext=$tmpdir/quarkse_em_fssqrt.so
 } elseif { [check_target_arc600] } {
     lappend nsim_flags \
 	-p nsim_isa_family=a600 \

--- a/dejagnu/tool-extra.exp
+++ b/dejagnu/tool-extra.exp
@@ -115,6 +115,11 @@ proc check_target_quarkse_em { } {
     return [check_target_arc "__ARC_FPX_QUARK__"]
 }
 
+# Return 1 if we compile for QuarkSE2 ARC EM
+proc check_target_quarkse2_em { } {
+    return [check_target_arc "__ARC_FPU_QUARK2__"]
+}
+
 # Return 1 if we compile for ARC600
 proc check_target_arc600 { } {
     return [check_target_arc "__ARC600__"]


### PR DESCRIPTION
2016-10-05  Claudiu Zissulescu  claziss@synopsys.com

```
* dejagnu/baseboards/arc-sim-nsimdrv.exp: Add nsim commands for
quarkse2_em cpu.
* dejagnu/tool-extra.exp (check_target_quarkse2_em): New
procedure.
```
