### PR TITLE
Update Eclipse and JRE versions

### DIFF
--- a/release.mk
+++ b/release.mk
@@ -73,7 +73,7 @@ GIT_REFERENCE_ROOT :=
 
 IDE_PLUGIN_LOCATION :=
 
-JAVA_VERSION := 8u66
+JAVA_VERSION := 8u121
 
 # libusb is used by the OpenOCD for Windows
 LIBUSB_VERSION := 1.0.20
@@ -233,7 +233,7 @@ TOOLS_LINUXLE_HS_DIR_NATIVE := arc_gnu_$(RELEASE)_prebuilt_uclibc_le_archs_nativ
 PDF_DOC_FILE := $(abspath $(ROOT)/toolchain/doc/_build/latex/GNU_Toolchain_for_ARC.pdf)
 
 # IDE: vanilla Eclipse variables
-ECLIPSE_VERSION := mars-1
+ECLIPSE_VERSION := neon-2
 ECLIPSE_VANILLA_ZIP_WIN := eclipse-cpp-$(ECLIPSE_VERSION)-win32.zip
 ECLIPSE_VANILLA_TGZ_LINUX := eclipse-cpp-$(ECLIPSE_VERSION)-linux-gtk-x86_64.tar.gz
 # Coma separated list

--- a/windows-installer/build-installer.sh
+++ b/windows-installer/build-installer.sh
@@ -21,7 +21,7 @@
 
 # Params
 # Eclipse parameters copied from Makefile.release
-ECLIPSE_REPO=http://download.eclipse.org/releases/mars
+ECLIPSE_REPO=http://download.eclipse.org/releases/neon
 ECLIPSE_PREREQ=org.eclipse.tm.terminal.feature.feature.group
 
 if [ -z "$RELEASE_TAG" ]; then


### PR DESCRIPTION
The version of Eclipse is updated to the Neon-2(4.6), the JRE version is
updated to the latest Java 8 version -- 8u121.