### PR TITLE
Updated Eclipse and JRE versions

### DIFF
--- a/release.mk
+++ b/release.mk
@@ -83,7 +83,7 @@ GIT_REFERENCE_ROOT :=
 
 IDE_PLUGIN_LOCATION :=
 
-JAVA_VERSION := 8u121
+JAVA_VERSION := 8u152
 
 # libusb is used by the OpenOCD for Windows
 LIBUSB_VERSION := 1.0.20
@@ -265,16 +265,16 @@ TOOLS_UCLIBC_LE_HS_NATIVE_DIR := arc_gnu_$(RELEASE)_prebuilt_uclibc_le_archs_nat
 PDF_DOC_FILE := $(abspath $(ROOT)/toolchain/doc/_build/latex/GNU_Toolchain_for_ARC.pdf)
 
 # IDE: vanilla Eclipse variables
-ECLIPSE_VERSION := neon-3
+ECLIPSE_VERSION := oxygen-1a
 ECLIPSE_VANILLA_WIN_ZIP := eclipse-cpp-$(ECLIPSE_VERSION)-win32.zip
 ECLIPSE_VANILLA_LINUX_TGZ := eclipse-cpp-$(ECLIPSE_VERSION)-linux-gtk-x86_64.tar.gz
 # Coma separated list
 # Synopsys IT blocks some of the Eclipse mirrors, so an exact mirror is
 # specified - the one which is not blocked.
-ECLIPSE_REPO := http://ftp-stud.fht-esslingen.de/pub/Mirrors/eclipse/releases/neon
+ECLIPSE_REPO := http://ftp-stud.fht-esslingen.de/pub/Mirrors/eclipse/releases/oxygen
 # Coma separated list
-ECLIPSE_PREREQ :=  org.eclipse.tm.terminal.control,org.eclipse.tm.terminal.connector.serial,org.eclipse.tm.terminal.view.core,org.eclipse.tm.terminal.view.ui
-ECLIPSE_DL_LINK_BASE := http://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/neon/3
+ECLIPSE_PREREQ :=  org.eclipse.tm.terminal.control,org.eclipse.tm.terminal.view.core,org.eclipse.tm.terminal.view.ui
+ECLIPSE_DL_LINK_BASE := http://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/oxygen/1a
 
 # Java.
 JRE_LINUX_TGZ := jre-$(JAVA_VERSION)-linux-x64.tar.gz

--- a/windows-installer/build-installer.sh
+++ b/windows-installer/build-installer.sh
@@ -21,7 +21,7 @@
 
 # Params
 # Eclipse parameters copied from Makefile.release
-ECLIPSE_REPO=http://ftp-stud.fht-esslingen.de/pub/Mirrors/eclipse/releases/neon
+ECLIPSE_REPO=http://ftp-stud.fht-esslingen.de/pub/Mirrors/eclipse/releases/oxygen
 ECLIPSE_PREREQ=org.eclipse.tm.terminal.feature.feature.group
 
 if [ -z "$RELEASE_TAG" ]; then


### PR DESCRIPTION
JRE version is 8u152 now, Eclipse version is Oxygen.
Prereq are changed: tm.terminal.connector.serial is removed.