### PR TITLE
Add support of macOS builds

### DIFF
--- a/build-elf32.sh
+++ b/build-elf32.sh
@@ -120,6 +120,11 @@ else
     build_dir="$(echo "${PWD}")/bd-elf32"
 fi
 
+if [ "${HOST}" = "macos" ]
+then
+    macos_params="--with-guile=no"
+fi
+
 # Set up a logfile
 logfile="${LOGDIR}/elf32-build-$(date -u +%F-%H%M).log"
 rm -f "${logfile}"
@@ -389,7 +394,7 @@ else
 fi
 
 build_dir_init gdb
-configure_elf32 gdb gdb --disable-ld --disable-gas --disable-binutils \
+configure_elf32 gdb gdb --disable-ld --disable-gas --disable-binutils ${macos_params} \
     --enable-targets=arc-linux-uclibc $cxx_build
 make_target building all
 make_target installing ${HOST_INSTALL}-gdb

--- a/doc/maintainer/release.rst
+++ b/doc/maintainer/release.rst
@@ -117,6 +117,15 @@ that will be sourced by ``release.mk``.
    Default value
       ``y``
 
+.. envvar:: ENABLE_IDE_MACOS
+
+   Whether to build and upload IDE distributable package on macOS.
+
+   Possible values
+      ``y`` and ``n``
+   Default value
+      ``n``
+
 .. envvar:: ENABLE_IDE_PLUGINS_BUILD
 
    Whether to build IDE plugins as part of ARC GNU Toolchain or download prebuilt ZIP.


### PR DESCRIPTION
Now there is possibility to build bare metal toolchains, OpenOCD and
ARC GNU IDE on macOS