### PR TITLE
arc-versions: Skip checkout of libc & Linux kernel if they are not be…

### DIFF
--- a/arc-versions.sh
+++ b/arc-versions.sh
@@ -135,6 +135,24 @@ do
 	cd ${ARC_GNU}/${tool}
     fi
 
+    # Skip checkout of Linux if neither uClibc nor Glibs are being built
+    if [ "${DO_GLIBC}" = "no" ] && [ "${DO_UCLIBC}" = "no" ]
+    then
+        continue
+    fi
+
+    # Skip checkout of uClibc if we're not going to build it
+    if [ "${tool}" = "uclibc-ng" ] && [ "${DO_UCLIBC}" = "no" ]
+    then
+        continue
+    fi
+
+    # Skip checkout of Glibc if we're not going to build it
+    if [ "${tool}" = "glibc" ] && [ "${DO_GLIBC}" = "no" ]
+    then
+        continue
+    fi
+
     if [ "x${autopull}" = "x--auto-pull" ]
     then
 	# Fetch any new tags and branches.


### PR DESCRIPTION
…ing built

Even though in our readmes we suggest to clone all repos including
uClibc, Glibc & Linux kernel some advanced users may not follow those
suggestions closely as indeed neither Linux libc (uClibc or Glibc) nor
the Linux kernel itself make any sense when we only want to build Elf32 tools.

Thus we want to accommodate those corner-cases which we do now.