### PR TITLE
Sobolev rst2pdf

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -382,7 +382,7 @@ pdf_cover_template = '_templates/synopsys.tmpl'
 #pdf_use_toc = True
 
 # How many levels deep should the table of contents be?
-pdf_toc_depth = 2
+pdf_toc_depth = 3
 
 # Add section number to section references
 pdf_use_numbered_links = True

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,6 +3,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+Welcome to GNU Toolchain for ARC documentation!
+===============================================
 
 .. toctree::
    :maxdepth: 2
@@ -17,6 +19,8 @@
    man-pages
 
 
+Indices and tables
+==================
 
 * :ref:`genindex`
 * :ref:`search`


### PR DESCRIPTION
Fixes missing greeting & page title in HTML documentation in exchange on an extra level of chapters in the PDF docs.