### PR TITLE
docs: linux/kernel-build: Update for arc-2020.09

### DIFF
--- a/doc/linux/kernel-build.rst
+++ b/doc/linux/kernel-build.rst
@@ -64,7 +64,7 @@ sources::
 
     $ mkdir arc-2020.09-linux-guide
     $ cd arc-2020.09-linux-guide
-    $ wget https://buildroot.org/downloads/buildroot-2020.02.7.tar.bz2
+    $ wget https://buildroot.org/downloads/buildroot-2020.08.1.tar.bz2
     $ tar xf buildroot-2020.08.1.tar.bz2
 
 To build Linux and rootfs Buildroot should be configured. For the purpose of
@@ -134,7 +134,7 @@ Building
 To build Linux kernel image using that defconfig::
 
     $ mkdir output_hs
-    $ cd buildroot-20.02
+    $ cd buildroot-2020.08.01
     $ make O=`readlink -e ../output_hs` defconfig DEFCONFIG=`readlink -e ../hs_defconfig`
     $ cd ../output_hs
     $ make

--- a/doc/linux/kernel-build.rst
+++ b/doc/linux/kernel-build.rst
@@ -62,15 +62,15 @@ Check `Buildroot downloads page <http://buildroot.org/download.html>`_ for
 latest release. This guide further assumes latest snapshot. Get Buildroot
 sources::
 
-    $ mkdir arc-2020.03-linux-guide
-    $ cd arc-2020.03-linux-guide
-    $ wget https://buildroot.org/downloads/buildroot-2020.02.tar.bz2
-    $ tar xf buildroot-2020.02.tar.bz2
+    $ mkdir arc-2020.09-linux-guide
+    $ cd arc-2020.09-linux-guide
+    $ wget https://buildroot.org/downloads/buildroot-2020.02.7.tar.bz2
+    $ tar xf buildroot-2020.08.1.tar.bz2
 
 To build Linux and rootfs Buildroot should be configured. For the purpose of
 this guide, a custom "defconfig" file will be created and then will be used to
 configure Buildroot. Custom "defconfig" file can be located anywhere and have
-any name. For example it can be ``arc-2020.03-linux-guide/hs_defconfig``.
+any name. For example it can be ``arc-2020.09-linux-guide/hs_defconfig``.
 Contents of this file should be following::
 
     BR2_arcle=y
@@ -78,14 +78,14 @@ Contents of this file should be following::
     BR2_TOOLCHAIN_EXTERNAL=y
     BR2_TOOLCHAIN_EXTERNAL_CUSTOM=y
     BR2_TOOLCHAIN_EXTERNAL_DOWNLOAD=y
-    BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases/download/arc-2020.03-rc1/arc_gnu_2020.03-rc1_prebuilt_uclibc_le_archs_linux_install.tar.gz"
-    BR2_TOOLCHAIN_EXTERNAL_GCC_9=y
-    BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_15=y
+    BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases/download/arc-2020.09-rc1/arc_gnu_2020.09-rc1_prebuilt_uclibc_le_archs_linux_install.tar.gz"
+    BR2_TOOLCHAIN_EXTERNAL_GCC_10=y
+    BR2_TOOLCHAIN_EXTERNAL_HEADERS_5_7=y
     BR2_TOOLCHAIN_EXTERNAL_LOCALE=y
     BR2_TOOLCHAIN_EXTERNAL_HAS_SSP=y
     BR2_TOOLCHAIN_EXTERNAL_CXX=y
     BR2_LINUX_KERNEL=y
-    BR2_LINUX_KERNEL_DEFCONFIG="nsim_hs"
+    BR2_LINUX_KERNEL_DEFCONFIG="haps_hs"
     BR2_LINUX_KERNEL_VMLINUX=y
     BR2_PACKAGE_GDB=y
     BR2_PACKAGE_GDB_DEBUGGER=y
@@ -102,6 +102,7 @@ Important notes about modifying Buildroot defconfig:
   =================== =======================
   Toolchain version   Linux headers version
   =================== =======================
+  2020.09             5.7
   2020.03             4.15
   2019.09             4.15
   2019.03             4.15
@@ -142,7 +143,7 @@ It's necessary to pass an absolute path to Buildroot, because there is the issue
 with a relative path.
 
 After that there will be Linux kernel image file
-``arc-2020.03-linux-guide/output/images/vmlinux``.
+``arc-2020.09-linux-guide/output/images/vmlinux``.
 
 
 Running on nSIM
@@ -151,7 +152,7 @@ Running on nSIM
 Linux configuration in the provided Buildroot defconfig is for the standalone
 nSIM. This kernel image can be run directly on nSIM, without any other
 additional software. Assuming current directory is
-``arc-2020.03-linux-guide``::
+``arc-2020.09-linux-guide``::
 
     $ $NSIM_HOME/bin/nsimdrv -prop=nsim_isa_family=av2hs -prop=nsim_isa_core=3 -prop=chipid=0xffff -prop=nsim_isa_atomic_option=1 -prop=nsim_isa_ll64_option=1 -prop=nsim_mmu=4 -prop=mmu_pagesize=8192 -prop=mmu_super_pagesize=2097152 -prop=mmu_stlb_entries=16 -prop=mmu_ntlb_ways=4 -prop=mmu_ntlb_sets=128 -prop=icache=32768,64,4,0 -prop=dcache=16384,64,2,0 -prop=nsim_isa_shift_option=2 -prop=nsim_isa_swap_option=1 -prop=nsim_isa_bitscan_option=1 -prop=nsim_isa_sat=1 -prop=nsim_isa_div_rem_option=1 -prop=nsim_isa_mpy_option=9 -prop=nsim_isa_enable_timer_0=1 -prop=nsim_isa_enable_timer_1=1 -prop=nsim_isa_number_of_interrupts=32 -prop=nsim_isa_number_of_external_interrupts=32 -prop=isa_counters=1 -prop=nsim_isa_pct_counters=8 -prop=nsim_isa_pct_size=48 -prop=nsim_isa_pct_interrupt=1 -prop=nsim_mem-dev=uart0,base=0xc0fc1000,irq=24 -prop=nsim_isa_aps_feature=1 -prop=nsim_isa_num_actionpoints=4 -prop=nsim_isa_rtc_option=1 output_hs/images/vmlinux
 
@@ -189,13 +190,13 @@ differences::
     BR2_TOOLCHAIN_EXTERNAL=y
     BR2_TOOLCHAIN_EXTERNAL_CUSTOM=y
     BR2_TOOLCHAIN_EXTERNAL_DOWNLOAD=y
-    BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases/download/arc-2020.03-rc1/arc_gnu_2020.03-rc1_prebuilt_glibc_le_archs_linux_install.tar.gz"
-    BR2_TOOLCHAIN_EXTERNAL_GCC_9=y
-    BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_15=y
+    BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases/download/arc-2020.09-rc1/arc_gnu_2020.09-rc1_prebuilt_glibc_le_archs_linux_install.tar.gz"
+    BR2_TOOLCHAIN_EXTERNAL_GCC_10=y
+    BR2_TOOLCHAIN_EXTERNAL_HEADERS_5_7=y
     BR2_TOOLCHAIN_EXTERNAL_CUSTOM_GLIBC=y
     BR2_TOOLCHAIN_EXTERNAL_CXX=y
     BR2_LINUX_KERNEL=y
-    BR2_LINUX_KERNEL_DEFCONFIG="nsim_hs"
+    BR2_LINUX_KERNEL_DEFCONFIG="haps_hs"
     BR2_LINUX_KERNEL_VMLINUX=y
     BR2_PACKAGE_GDB=y
     BR2_PACKAGE_GDB_DEBUGGER=y
@@ -210,10 +211,10 @@ Process of building kernel for ARC 770 is similar to what is for ARC HS. It is
 required only to change several option in Buildroot defconfig:
 
   * ``BR2_archs38=y`` with ``BR2_arc770d=y``
-  * ``BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases/download/arc-2020.03-rc1/arc_gnu_2020.03-rc1_prebuilt_uclibc_le_archs_linux_install.tar.gz"``
+  * ``BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases/download/arc-2020.09-rc1/arc_gnu_2020.09-rc1_prebuilt_uclibc_le_archs_linux_install.tar.gz"``
     with
-    ``BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases/download/arc-2020.03-rc1/arc_gnu_2020.03-rc1_prebuilt_uclibc_le_arc700_linux_install.tar.gz"``
-  * ``BR2_LINUX_KERNEL_DEFCONFIG="nsim_hs"`` with
+    ``BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases/download/arc-2020.09-rc1/arc_gnu_2020.09-rc1_prebuilt_uclibc_le_arc700_linux_install.tar.gz"``
+  * ``BR2_LINUX_KERNEL_DEFCONFIG="haps_hs"`` with
     ``BR2_LINUX_KERNEL_DEFCONFIG="nsim_700"``
 
 Then repeat steps from :ref`linux-building-label` section of this document to build


### PR DESCRIPTION
docs: linux/kernel-build: Update for arc-2020.09 

* Updated reference to pre-built arc-2020.09 toolchain tarballs
* Updated reference to buildroot-2020.8.1 tarball
* Updated Buildroot configuration to match pre-built tools:
   * GCC version bumped to v10
   * Linux headers bumped to v5.7