### PR TITLE
arc-versions: fix checking out repos when building without uclibc and glibc

### DIFF
--- a/arc-versions.sh
+++ b/arc-versions.sh
@@ -136,7 +136,7 @@ do
     fi
 
     # Skip checkout of Linux if neither uClibc nor Glibs are being built
-    if [ "${DO_GLIBC}" = "no" ] && [ "${DO_UCLIBC}" = "no" ]
+    if [ "${tool}" = "linux" ] && [ "${DO_GLIBC}" = "no" ] && [ "${DO_UCLIBC}" = "no" ]
     then
         continue
     fi


### PR DESCRIPTION
This PR fixes an issue where `arc-versions.sh` would not update all involved repositories when building without uclib and glibc.

The build command I am using:

```
$ ./build-all.sh --no-uclibc
```