### PR TITLE
doc: use a raw string before escape character

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -221,7 +221,7 @@ latex_elements = {
 
 # Additional stuff for the LaTeX preamble.
 # Increase limitations on the number of floats.
-'preamble': '\usepackage{float}',
+'preamble': r'\usepackage{float}',
 
 # Latex figure (float) alignment to fix image location in the document.
 'figure_align': 'H',


### PR DESCRIPTION
 use a raw string to avoid '\u' introduce a 32-bit unicode character

Signed-off-by: Jingru Wang <jingru@synopsys.com>