### PR TITLE
doc: Fixed appnote URL's

### DIFF
--- a/doc/man-pages.rst
+++ b/doc/man-pages.rst
@@ -3,7 +3,7 @@ GNU man pages
 
 Man pages for ARC GCC and Binutils can be found at following links:
 
-* `GCC man pages <https://embarc.org/man-pages/gcc>`_
-* `GNU Assember man pages <https://embarc.org/man-pages/as>`_
-* `GNU Binutils man pages <https://embarc.org/man-pages/binutils>`_
-* `GNU Linker man pages <https://embarc.org/man-pages/ld>`_.
+* `GCC man pages <https://foss-for-synopsys-dwc-arc-processors.github.io/man-pages/gcc>`_
+* `GNU Assember man pages <https://foss-for-synopsys-dwc-arc-processors.github.io/man-pages/as/>`_
+* `GNU Binutils man pages <https://foss-for-synopsys-dwc-arc-processors.github.io/man-pages/binutils>`_
+* `GNU Linker man pages <https://foss-for-synopsys-dwc-arc-processors.github.io/man-pages/ld>`_.

--- a/windows-installer/installer.nsi
+++ b/windows-installer/installer.nsi
@@ -154,7 +154,7 @@ section ""
     CreateShortCut "$SMPROGRAMS\${startmenu_dir}\GNU Toolchain User Guide.lnk" \
 	"$INSTDIR\share\doc\GNU_Toolchain_for_ARC.pdf"
     CreateShortCut "$SMPROGRAMS\${startmenu_dir}\IDE Documentation online.lnk" \
-      "http://embarc.org/toolchain/ide/index.html"
+      "https://foss-for-synopsys-dwc-arc-processors.github.io/toolchain/ide/index.html"
     CreateShortCut "$SMPROGRAMS\${startmenu_dir}\IDE Releases on GitHub.lnk" \
       "https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases"
 SectionEnd


### PR DESCRIPTION
We used to host embarc.org web-site on GitHub.io platform,
but now we moved to a stand-alone solution.

Signed-off-by: Jingru Wang <jingru@synopsys.com>