### PR TITLE
arc-init.sh: enable fortran support

### DIFF
--- a/arc-init.sh
+++ b/arc-init.sh
@@ -411,7 +411,7 @@ configure_linux_stage2() {
 	--enable-fast-install=N/A \
 	--with-endian=$ARC_ENDIAN \
 	$DISABLEWERROR \
-	--enable-languages=c,c++ \
+	--enable-languages=c,c++,fortran \
 	--prefix="$INSTALLDIR" \
 	--enable-shared \
 	--without-newlib \

--- a/doc/maintainer/manual-build.rst
+++ b/doc/maintainer/manual-build.rst
@@ -220,7 +220,7 @@ Build Stage 2 GCC::
         --enable-fast-install=N/A \
         --with-endian=little \
         --disable-werror \
-        --enable-languages=c,c++ \
+        --enable-languages=c,c++,fortran \
         --prefix=${INSTALLDIR} \
         --enable-shared \
         --without-newlib \


### PR DESCRIPTION
Enable fortran for linux toolchain.

Signed-off-by: Artem Panfilov <artemp@synopsys.com>