### PR TITLE
dejagnu: remove "arc_get_cflags" from arc64-qemu baseboard

### DIFF
--- a/dejagnu/baseboards/arc64-qemu.exp
+++ b/dejagnu/baseboards/arc64-qemu.exp
@@ -54,7 +54,7 @@ set_board_info sim_time_limit 15
 set_board_info is_simulator 1
 
 set_board_info compiler  "[find_gcc]"
-set_board_info cflags    "[libgloss_include_flags] [newlib_include_flags] [arc_get_cflags]"
+set_board_info cflags    "[libgloss_include_flags] [newlib_include_flags]"
 set_board_info ldflags   "[libgloss_link_flags] ${xldflags} [newlib_link_flags]"
 # No linker script needed.
 set_board_info ldscript ""


### PR DESCRIPTION
Remove "arc_get_cflags" because it was causing appending
nosys.specs to cflags:
https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/blob/arc-dev/dejagnu/arc-common.exp#L57

Signed-off-by: Artem Panfilov <artemp@synopsys.com>