### PR TITLE
release.mk: install tcftool only for bare-metal

### DIFF
--- a/release.mk
+++ b/release.mk
@@ -659,37 +659,31 @@ $O/.stamp_elf_be_tarball: $O/.stamp_elf_be_built
 
 $O/.stamp_uclibc_le_700_built: $(TOOLS_ALL_DEPS-y) | $(TOOLS_ALL_ORDER_DEPS-y)
 	$(call copy_prebuilt,arc-arc700-linux-uclibc,$(TOOLS_UCLIBC_LE_700_HOST_DIR))
-	$(call copy_tcftool_linux,$O/$(TOOLS_UCLIBC_LE_700_HOST_DIR))
 	$(call copy_pdf_doc_file,$O/$(TOOLS_UCLIBC_LE_700_HOST_DIR))
 	touch $@
 
 $O/.stamp_uclibc_be_700_built: $(TOOLS_ALL_DEPS-y) | $(TOOLS_ALL_ORDER_DEPS-y)
 	$(call copy_prebuilt,arceb-arc700-linux-uclibc,$(TOOLS_UCLIBC_BE_700_HOST_DIR))
-	$(call copy_tcftool_linux,$O/$(TOOLS_UCLIBC_BE_700_HOST_DIR))
 	$(call copy_pdf_doc_file,$O/$(TOOLS_UCLIBC_BE_700_HOST_DIR))
 	touch $@
 
 $O/.stamp_uclibc_le_hs_built: $(TOOLS_ALL_DEPS-y) | $(TOOLS_ALL_ORDER_DEPS-y)
 	$(call copy_prebuilt,arc-archs-linux-uclibc,$(TOOLS_UCLIBC_LE_HS_HOST_DIR))
-	$(call copy_tcftool_linux,$O/$(TOOLS_UCLIBC_LE_HS_HOST_DIR))
 	$(call copy_pdf_doc_file,$O/$(TOOLS_UCLIBC_LE_HS_HOST_DIR))
 	touch $@
 
 $O/.stamp_uclibc_be_hs_built: $(TOOLS_ALL_DEPS-y) | $(TOOLS_ALL_ORDER_DEPS-y)
 	$(call copy_prebuilt,arceb-archs-linux-uclibc,$(TOOLS_UCLIBC_BE_HS_HOST_DIR))
-	$(call copy_tcftool_linux,$O/$(TOOLS_UCLIBC_BE_HS_HOST_DIR))
 	$(call copy_pdf_doc_file,$O/$(TOOLS_UCLIBC_BE_HS_HOST_DIR))
 	touch $@
 
 $O/.stamp_glibc_le_hs_built: $(TOOLS_ALL_DEPS-y) | $(TOOLS_ALL_ORDER_DEPS-y)
 	$(call copy_prebuilt,arc-archs-linux-gnu,$(TOOLS_GLIBC_LE_HS_HOST_DIR))
-	$(call copy_tcftool_linux,$O/$(TOOLS_GLIBC_LE_HS_HOST_DIR))
 	$(call copy_pdf_doc_file,$O/$(TOOLS_GLIBC_LE_HS_HOST_DIR))
 	touch $@
 
 $O/.stamp_glibc_be_hs_built: $(TOOLS_ALL_DEPS-y) | $(TOOLS_ALL_ORDER_DEPS-y)
 	$(call copy_prebuilt,arceb-archs-linux-gnu,$(TOOLS_GLIBC_BE_HS_HOST_DIR))
-	$(call copy_tcftool_linux,$O/$(TOOLS_GLIBC_BE_HS_HOST_DIR))
 	$(call copy_pdf_doc_file,$O/$(TOOLS_GLIBC_BE_HS_HOST_DIR))
 	touch $@
 


### PR DESCRIPTION
There is no need to install tcftool for Linux toolchains.

Signed-off-by: Artem Panfilov <artemp@synopsys.com>