### PR TITLE
README.md: Added libtool-bin dependency for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ website](http://gcc.gnu.org/install/prerequisites.html)
 
 ```shell
 sudo apt update
-sudo apt install -y autoconf help2man libtool texinfo byacc flex libncurses5-dev zlib1g-dev \
+sudo apt install -y autoconf help2man libtool libtool-bin texinfo byacc flex libncurses5-dev zlib1g-dev \
                     libexpat1-dev texlive build-essential git wget gawk \
                     bison xz-utils make python3 rsync locales
 ```


### PR DESCRIPTION
When I try to configure Crosstool-NG on plain Ubuntu 20.04 I see an error about absence of `libtool`. Installing `libtool-bin` package resolves this problem.