### PR TITLE
Fix markdown linter in GitHub Actions

### DIFF
--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '10'
+          node-version: '16'
       - name: Install markdownlint
         run: npm install -g markdownlint-cli
       - name: Run Markdownlint

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ There're muliple ways to get MinGW installed:
 
 Please note, due to recent changes in Crosstool-NG it's required to
 do a tiny change in its configuration to escape a problem of
-missing `libwinpthread-1.dll`, see https://github.com/crosstool-ng/crosstool-ng/issues/1869
+missing `libwinpthread-1.dll`, see Crosstool-NG [issue #1869](https://github.com/crosstool-ng/crosstool-ng/issues/1869)
 for more details. And required change consists of removal of `CT_THREADS_POSIX` option,
 i.e. in Crosstools-NG's `menuconfig` deselect it.
 


### PR DESCRIPTION
These 2 commits fix a broken markdown linter in this repository and fixes all warnings in `README.md`.