### PR TITLE
doc: Security update by Dependabot

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -9,13 +9,13 @@ importlib-metadata==6.0.0
 Jinja2==3.1.2
 MarkupSafe==2.1.1
 packaging==23.0
-Pillow==9.4.0
+Pillow==10.2.0
 Pygments==2.14.0
 pytz==2022.7.1
 PyYAML==6.0.1
-reportlab==3.6.12
+reportlab==4.0.9
 requests==2.28.2
-rst2pdf==0.99
+rst2pdf==0.101
 smartypants==2.0.1
 snowballstemmer==2.2.0
 Sphinx==5.3.0

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -12,7 +12,7 @@ packaging==23.0
 Pillow==9.4.0
 Pygments==2.14.0
 pytz==2022.7.1
-PyYAML==6.0
+PyYAML==6.0.1
 reportlab==3.6.12
 requests==2.28.2
 rst2pdf==0.99


### PR DESCRIPTION
Upgrade the Python Pillow package to 10.2.0 by the Dependabot alert. This package affects on other packages: PyYAML, reportlab and rst2pdf, which were also upgraded in this commit.