### PR TITLE
arcv: Update expect scripts of dejagnu for ARC-V targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,9 @@ Prefixes which start with `arc-` correspond to little endian toolchains. Prefixe
 ### Using nSIM simulator to run bare metal ARC applications
 
 nSIM simulator supports GNU IO hostlink used by the libc library of bare metal
-GNU toolchain for ARC. nSIM option `nsim_emt=1` enables GNU IO hostlink.
+GNU toolchain for ARC. nSIM option `nsim_emt=1` enables GNU IO hostlink. nSIM
+simulator also supports semihosting, which is essential for ARC-V targets, more
+details can be found in nSIM documentation.
 
 To start nSIM in gdbserver mode for ARC EM6:
 

--- a/dejagnu/arc-common.exp
+++ b/dejagnu/arc-common.exp
@@ -49,18 +49,22 @@ proc arc_get_cflags {} {
 
     # Use cflags instead ldflags because lto tests of ld testsuite ignore
     # ldflags
-    if { ![info exists env(ARC_HOSTLINK_LIBRARY)] } {
-	if [board_info $board exists arc,hostlink] {
-	    if { [board_info $board arc,hostlink] == "nsim" } {
-		lappend cflags --specs=nsim.specs
-	    } elseif { [board_info $board arc,hostlink] == "metaware" } {
-		lappend cflags --specs=hl.specs
-	    } else {
-		lappend cflags --specs=nosys.specs
-	    }
-	} else {
-	    lappend cflags --specs=nosys.specs
-	}
+    if {![info exists env(ARC_HOSTLINK_LIBRARY)]} {
+        if {[board_info $board exists arc,hostlink]} {
+            if {[board_info $board arc,hostlink] == "nsim"} {
+                lappend cflags --specs=nsim.specs
+            } elseif {[board_info $board arc,hostlink] == "metaware"} {
+                lappend cflags --specs=hl.specs
+            } elseif {[board_info $board arc,hostlink] == "semihost"} {
+                lappend cflags --specs=semihost.specs --specs=arcv.specs \
+                    -mabi=ilp32 -march=rv32im_zba_zbb_zbs_zca_zcb_zcmp_zicsr \
+                    -T arcv.ld
+            } else {
+                lappend cflags --specs=nosys.specs
+            }
+        } else {
+            lappend cflags --specs=nosys.specs
+        }
     }
 
     # GCC generates improper DWARF info when frame-pointer is involved - all

--- a/dejagnu/baseboards/arc-nsim.exp
+++ b/dejagnu/baseboards/arc-nsim.exp
@@ -100,25 +100,27 @@ if { $tool == "libstdc++" } {
 }
 
 # Check if nsim_download_elf_sections option is required - whether nSIM version
-# is > 2015.06. If revision.txt doesn't exist - this is a private verification
-# build of nSIM, so assume that this is the latest version.
+# is > 2015.06 and a target is not ARC-V. If revision.txt doesn't exist - this
+# is a private verification build of nSIM, so assume that this is the latest
+# version.
 set nsim_version_path "$::env(NSIM_HOME)/revision.txt"
-if [file exists $nsim_version_path] {
-    set nsim_version_fid [open $nsim_version_path r]
-    set nsim_version_text [read $nsim_version_fid]
-    close $nsim_version_fid
-    regexp "Version\\s+: (\\d+)\.(\\d+)" $nsim_version_text -> \
-	nsim_version_year nsim_version_month
-    if { $nsim_version_year > 2015 || \
-	($nsim_version_year == 2015 && $nsim_version_month > 6) } {
-	# Avoid performance penalty of useless initialization of heap and stack
-	# sections.
-	lappend nsim_flags "-on nsim_download_elf_sections"
+if {![check_target_arcv]} {
+    if {[file exists $nsim_version_path]} {
+        set nsim_version_fid [open $nsim_version_path r]
+        set nsim_version_text [read $nsim_version_fid]
+        close $nsim_version_fid
+        regexp "Version\\s+: (\\d+)\.(\\d+)" $nsim_version_text -> \
+            nsim_version_year nsim_version_month
+        if {$nsim_version_year > 2015 || \
+	        ($nsim_version_year == 2015 && $nsim_version_month > 6)} {
+            # Avoid performance penalty of useless initialization of heap and
+            # stack sections.
+            lappend nsim_flags "-on nsim_download_elf_sections"
+        }
+    } else {
+        lappend nsim_flags "-on nsim_download_elf_sections"
     }
-} else {
-    lappend nsim_flags "-on nsim_download_elf_sections"
 }
-
 set_board_info nsim_flags [join $nsim_flags]
 
 # nSIM is an exclusive resource -- only one client can connect at a time.

--- a/dejagnu/baseboards/arc-sim-nsimdrv.exp
+++ b/dejagnu/baseboards/arc-sim-nsimdrv.exp
@@ -80,23 +80,26 @@ if { $tool == "libstdc++" } {
 }
 
 # Check if nsim_download_elf_sections option is required - whether nSIM version
-# is > 2015.06. If revision.txt doesn't exist - this is a private verification
-# build of nSIM, so assume that this is the latest version.
+# is > 2015.06 and a target is not ARC-V. If revision.txt doesn't exist - this
+# is a private verification build of nSIM, so assume that this is the latest
+# version.
 set nsim_version_path "$::env(NSIM_HOME)/revision.txt"
-if [file exists $nsim_version_path] {
-    set nsim_version_fid [open $nsim_version_path r]
-    set nsim_version_text [read $nsim_version_fid]
-    close $nsim_version_fid
-    regexp "Version\\s+: (\\d+)\.(\\d+)" $nsim_version_text -> \
-	nsim_version_year nsim_version_month
-    if { $nsim_version_year > 2015 || \
-	($nsim_version_year == 2015 && $nsim_version_month > 6) } {
-	# Avoid performance penalty of useless initialization of heap and stack
-	# sections.
-	lappend nsim_flags "-on nsim_download_elf_sections"
+if {![check_target_arcv]} {
+    if {[file exists $nsim_version_path]} {
+        set nsim_version_fid [open $nsim_version_path r]
+        set nsim_version_text [read $nsim_version_fid]
+        close $nsim_version_fid
+        regexp "Version\\s+: (\\d+)\.(\\d+)" $nsim_version_text -> \
+            nsim_version_year nsim_version_month
+        if {$nsim_version_year > 2015 || \
+            ($nsim_version_year == 2015 && $nsim_version_month > 6)} {
+            # Avoid performance penalty of useless initialization of heap and
+            # stack sections.
+            lappend nsim_flags "-on nsim_download_elf_sections"
+        }
+    } else {
+        lappend nsim_flags "-on nsim_download_elf_sections"
     }
-} else {
-    lappend nsim_flags "-on nsim_download_elf_sections"
 }
 
 # Hostlink library support
@@ -106,8 +109,9 @@ if { [info exists env(ARC_HOSTLINK_LIBRARY)] } {
 } elseif { [info exists env(ARC_NSIM_HOSTLINK)] } {
     set_board_info arc,hostlink $env(ARC_NSIM_HOSTLINK)
 
-    if { [board_info $board arc,hostlink] != "metaware" && \
-	 [board_info $board arc,hostlink] != "nsim" } {
+    if {[board_info $board arc,hostlink] != "metaware" && \
+	 [board_info $board arc,hostlink] != "nsim" && \
+	 [board_info $board arc,hostlink] != "semihost"} {
         perror "Unknown nSIM HOSTLINK type $env(ARC_NSIM_HOSTLINK)"
         exit 1
     }
@@ -210,6 +214,13 @@ if { [check_target_arc64_64] } {
 	-p nsim_isa_family=av2em \
 	-p nsim_isa_core=3 \
 	-on nsim_isa_sat
+} elseif {[check_target_arcv]} {
+    set ext "-all.i.zicsr.zifencei.zihintpause.b.zca.zcb.zcmp.zcmt.a.m.zbb"
+    lappend nsim_flags \
+        -p nsim_isa_family=rv32 \
+        -p nsim_isa_ext=${ext} \
+        -p nsim_semihosting=1 \
+        -off=enable_exceptions
 } else {
     perror "Unknown CPU configuration"
 }

--- a/dejagnu/tool-extra.exp
+++ b/dejagnu/tool-extra.exp
@@ -86,6 +86,11 @@ proc compile_quarkse_em_nsim_apex { } {
     }
 }
 
+# Return 1 if we compile for ARC-V
+proc check_target_arcv { } {
+    return [check_target_arc "__riscv"]
+}
+
 # Return 1 if we compile for ARC64
 proc check_target_arc64_64 { } {
     return [check_target_arc "__ARC64_ARCH64__"]


### PR DESCRIPTION
These updates provide commands to check compilation and execution, just like the `abs-1.x0` test:
```
/project/toolchains/riscv64-unknown-elf/bin/riscv64-elf-gcc  \
    /project/sources/src/gcc/gcc/testsuite/gcc.c-torture/execute/builtins/abs-1.c \
    /project/sources/src/gcc/gcc/testsuite/gcc.c-torture/execute/builtins/abs-1-lib.c \
    /project/sources/src/gcc/gcc/testsuite/gcc.c-torture/execute/builtins/lib/main.c  \
    -mtune=rmx100   -dumpbase "" -fdiagnostics-plain-output  -w  -O0  -fno-builtin-abs   \
    --specs=semihost.specs --specs=arcv.specs \
    -mabi=ilp32 -march=rv32im_zba_zbb_zbs_zca_zcb_zcmp_zicsr -T arcv.ld  \
    -Wl,--defsym=__DEFAULT_HEAP_SIZE=256m -Wl,--defsym=__DEFAULT_STACK_SIZE=1024m  \
    -Wl,-wrap,exit -Wl,-wrap,_exit -Wl,-wrap,main -Wl,-wrap,abort -Wl,gcc_tg.o -lm  \
    -o /project/shared-scripts/dejagnu/../../out/dejagnu/abs-1.x0
```
```
mwdt_2023.12/nSIM/nSIM_64//bin/nsimdrv \
    -on nsim_isa_enable_timer_0 -on nsim_isa_enable_timer_1 -off invalid_instruction_interrupt \
    -off memory_exception_interrupt -p nsim_isa_family=rv32 \
    -p nsim_isa_ext=-all.i.zicsr.zifencei.zihintpause.b.zca.zcb.zcmp.zcmt.a.m.zbb \
    -p nsim_semihosting=1 -off=enable_exceptions -p nsim_isa_shift_option=0 \
    -p nsim_isa_bitscan_option=0 \
    /project/shared-scripts/dejagnu/../../out/dejagnu/abs-1.x0
```

Dejagnu detailed output for the test `abs-1.x0`:
```
...
Testing gcc.c-torture/execute/builtins/abs-1.c,  -O0 
Checking /project/toolchains/riscv64-unknown-elf/bin/riscv64-elf-gcc
file /project/toolchains/riscv64-unknown-elf/bin/riscv64-elf-gcc is executable
doing compile
Invoking the compiler as /project/toolchains/riscv64-unknown-elf/bin/riscv64-elf-gcc  /project/sources/src/gcc/gcc/testsuite/gcc.c-torture/execute/builtins/abs-1.c /project/sources/src/gcc/gcc/testsuite/gcc.c-torture/execute/builtins/abs-1-lib.c /project/sources/src/gcc/gcc/testsuite/gcc.c-torture/execute/builtins/lib/main.c  -mtune=rmx100   -dumpbase "" -fdiagnostics-plain-output  -w  -O0  -fno-builtin-abs   --specs=semihost.specs --specs=arcv.specs -mabi=ilp32 -march=rv32im_zba_zbb_zbs_zca_zcb_zcmp_zicsr -T arcv.ld  -Wl,--defsym=__DEFAULT_HEAP_SIZE=256m -Wl,--defsym=__DEFAULT_STACK_SIZE=1024m  -Wl,-wrap,exit -Wl,-wrap,_exit -Wl,-wrap,main -Wl,-wrap,abort -Wl,gcc_tg.o -lm  -o /project/shared-scripts/dejagnu/../../out/dejagnu/abs-1.x0
Setting timeout to 300
Executing on host: /project/toolchains/riscv64-unknown-elf/bin/riscv64-elf-gcc  /project/sources/src/gcc/gcc/testsuite/gcc.c-torture/execute/builtins/abs-1.c /project/sources/src/gcc/gcc/testsuite/gcc.c-torture/execute/builtins/abs-1-lib.c /project/sources/src/gcc/gcc/testsuite/gcc.c-torture/execute/builtins/lib/main.c  -mtune=rmx100   -dumpbase "" -fdiagnostics-plain-output  -w  -O0  -fno-builtin-abs   --specs=semihost.specs --specs=arcv.specs -mabi=ilp32 -march=rv32im_zba_zbb_zbs_zca_zcb_zcmp_zicsr -T arcv.ld  -Wl,--defsym=__DEFAULT_HEAP_SIZE=256m -Wl,--defsym=__DEFAULT_STACK_SIZE=1024m  -Wl,-wrap,exit -Wl,-wrap,_exit -Wl,-wrap,main -Wl,-wrap,abort -Wl,gcc_tg.o -lm  -o /project/shared-scripts/dejagnu/../../out/dejagnu/abs-1.x0    (timeout = 300)
pid is 750116 -750116
pid is -1
waitres is 750116 exp8 0 0
output is  status 0
Checking pattern "sparc-*-sunos*" with x86_64-pc-linux-gnu
Checking pattern "alpha*-*-*" with x86_64-pc-linux-gnu
Checking pattern "hppa*-*-hpux*" with x86_64-pc-linux-gnu
Checking pattern "sparc-*-sunos*" with x86_64-pc-linux-gnu
Checking pattern "alpha*-*-*" with x86_64-pc-linux-gnu
Checking pattern "hppa*-*-hpux*" with x86_64-pc-linux-gnu
check_cached_effective_target exceptions_enabled: returning 1 for arc-sim-nsimdrv
Checking x86_64-pc-linux-gnu against x86_64-pc-linux-gnu
Checking /global/apps/arcnsim_2023.03/nSIM_64/bin/nsimdrv
file /global/apps/arcnsim_2023.03/nSIM_64/bin/nsimdrv is executable
spawning command  /global/apps/arcnsim_2023.03/nSIM_64/bin/nsimdrv -on nsim_isa_enable_timer_0 -on nsim_isa_enable_timer_1 -off invalid_instruction_interrupt -off memory_exception_interrupt -p nsim_isa_family=rv32 -p nsim_isa_ext=-all.i.zicsr.zifencei.zihintpause.b.zca.zcb.zcmp.zcmt.a.m.zbb -p nsim_semihosting=1 -off=enable_exceptions -p nsim_isa_shift_option=0 -p nsim_isa_bitscan_option=0 /project/shared-scripts/dejagnu/../../out/dejagnu/abs-1.x0 
Closing the remote shell exp8
pid is -1
Shell closed.
Output is 
*** EXIT code 0

Return status was: 0
...
```