### PR TITLE
Refactor dejagnu scripts to fix all stylistic and functional errors

### DIFF
--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -1,0 +1,24 @@
+name: "Toolchain CI"
+
+on:
+  push:
+    branches: [arc-releases]
+  pull_request:
+    branches: [arc-releases]
+
+jobs:
+  tclint:
+    name: Lint a set of Expect scripts for dejagnu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          pip install tclint
+
+      - name: Lint scripts
+        run: |
+          tclint $(find dejagnu/ \( -name "arc*.exp" -o -name "nsim*.exp" \)) \
+            --show-categories

--- a/dejagnu/arc-common.exp
+++ b/dejagnu/arc-common.exp
@@ -18,15 +18,15 @@
 proc arc_get_multilib_options {} {
     global env
 
-    if { [info exists env(ARC_MULTILIB_OPTIONS)] } {
-	if { [regexp "^-m" $env(ARC_MULTILIB_OPTIONS)] || \
-	    [string length [string trim $env(ARC_MULTILIB_OPTIONS)]] == 0 } {
-	    return $env(ARC_MULTILIB_OPTIONS)
-	} else {
-	    return "-m$env(ARC_MULTILIB_OPTIONS)"
-	}
+    if {[info exists env(ARC_MULTILIB_OPTIONS)]} {
+        if {[regexp "^-m" $env(ARC_MULTILIB_OPTIONS)] || \
+	    [string length [string trim $env(ARC_MULTILIB_OPTIONS)]] == 0} {
+            return $env(ARC_MULTILIB_OPTIONS)
+        } else {
+            return "-m$env(ARC_MULTILIB_OPTIONS)"
+        }
     } else {
-	return ""
+        return ""
     }
 }
 
@@ -40,9 +40,9 @@ proc arc_get_cflags {} {
     # that will cause compilation errors in Metaware due to unknown options.
     # Instead all options should be specified via COMPAT_OPTIONS varibles in
     # site.exp.
-    if { [board_info $board exists arc,is_gcc_compat_suite] &&
-	[string is true -strict [board_info $board arc,is_gcc_compat_suite]] } {
-	return ""
+    if {[board_info $board exists arc,is_gcc_compat_suite] &&
+	[string is true -strict [board_info $board arc,is_gcc_compat_suite]]} {
+        return ""
     }
 
     set cflags {}
@@ -74,8 +74,8 @@ proc arc_get_cflags {} {
     # some watchpoint tests fail, because they get an extra watchpoint value
     # change even though it is not a variable that has changed, by a FP
     # register in epilogue.
-    if { $tool == "gdb" } {
-	lappend cflags -fomit-frame-pointer
+    if {$tool == "gdb"} {
+        lappend cflags -fomit-frame-pointer
     }
 
     return [join $cflags]
@@ -89,17 +89,17 @@ proc arc_gdbserver_close {} {
 
     verbose "arc: arc_gdbserver_close"
 
-    if ![board_info $board exists gdbserver_id] {
-	return
+    if {![board_info $board exists gdbserver_id]} {
+        return
     }
 
     set gdbserver_id [board_info $board gdbserver_id]
-    if [catch {close -i $gdbserver_id}] {
-	verbose "openocd_close: failed to close $gdbserver_id: $errorInfo"
+    if {[catch {close -i $gdbserver_id}]} {
+        verbose "openocd_close: failed to close $gdbserver_id: $errorInfo"
     }
 
-    if [catch {wait -i $gdbserver_id}] {
-	verbose "openocd_close: failed to wait for $gdbserver_id: $errorInfo"
+    if {[catch {wait -i $gdbserver_id}]} {
+        verbose "openocd_close: failed to wait for $gdbserver_id: $errorInfo"
     }
 
     unset_board_info gdbserver_id
@@ -120,6 +120,7 @@ proc arc_gdbserver_start { } {
     # a single arguments instead of an argument list. I haven't found a way to
     # explode $args into a list in a way that would work with spawn. Using
     # [split $args] didn't helped.
+    # tclint-disable-next-line command-args
     eval "spawn $bin $args"
 
     set_board_info gdbserver_id $spawn_id
@@ -138,11 +139,11 @@ proc arc_openocd_start { } {
     set_board_info arc,gdbserver_prog [board_info $board arc,openocd_prog]
 
     set args "-f [board_info $board arc,openocd_cfg]"
-    if [board_info $board exists arc,openocd_log] {
-	append args " -l [board_info $board arc,openocd_log]"
+    if {[board_info $board exists arc,openocd_log]} {
+        append args " -l [board_info $board arc,openocd_log]"
     }
-    if [board_info $board exists arc,openocd_log_level] {
-	append args " -d[board_info $board arc,openocd_log_level]"
+    if {[board_info $board exists arc,openocd_log_level]} {
+        append args " -d[board_info $board arc,openocd_log_level]"
     }
 
     set_board_info arc,gdbserver_args $args

--- a/dejagnu/baseboards/arc-ashling-gdbserver.exp
+++ b/dejagnu/baseboards/arc-ashling-gdbserver.exp
@@ -22,16 +22,16 @@ search_and_load_file "library file" "arc-elf32-generic.exp" $boards_dir
 set opella_dir "[file dirname $env(DEJAGNU)]/extras/opella-xd"
 
 # Select XML tdesc based on processor family.
-if { [check_target_arc700] } {
+if {[check_target_arc700]} {
     set tdesc_file "opella-arc700-tdesc.xml"
     set reg_file "arc700-cpu.xml"
-} elseif { [check_target_arc600] || [check_target_arc601] } {
+} elseif {[check_target_arc600] || [check_target_arc601]} {
     set tdesc_file "opella-arc600-tdesc.xml"
     set reg_file "arc600-cpu.xml"
-} elseif { [check_target_archs] } {
+} elseif {[check_target_archs]} {
     set tdesc_file "opella-archs-tdesc.xml"
     set reg_file "arc-hs-cpu.xml"
-} elseif { [check_target_arcem] || [check_target_quarkse_em] } {
+} elseif {[check_target_arcem] || [check_target_quarkse_em]} {
     set tdesc_file "opella-arcem-tdesc.xml"
     set reg_file "arc-em-cpu.xml"
 } else {

--- a/dejagnu/baseboards/arc-elf32-generic.exp
+++ b/dejagnu/baseboards/arc-elf32-generic.exp
@@ -31,8 +31,8 @@ search_and_load_file "library file" "arc-common.exp" ${boards_dir}
 
 # GDB tests require special treatment, they ignore "gdb-comm" configuration
 # unless "monitor" GDB test suite configuration is loaded.
-if { $tool == "gdb" } {
-	load_lib "../config/monitor.exp"
+if {$tool == "gdb"} {
+    load_lib "../config/monitor.exp"
 }
 
 # Don't use any hostlink (--specs=nosys.specs).
@@ -48,9 +48,10 @@ append xldflags " -Wl,-marcv2elfx -L$::env(PWD)"
 
 # We only support newlib on this target. We assume that all multilib
 # options have been specified before we get here.
-set_board_info compiler  "[find_gcc]"
-set_board_info cflags    "[libgloss_include_flags] [newlib_include_flags] [arc_get_cflags]"
-set_board_info ldflags   "[libgloss_link_flags] ${xldflags} [newlib_link_flags]"
+set_board_info compiler "[find_gcc]"
+set_board_info cflags \
+    "[libgloss_include_flags] [newlib_include_flags] [arc_get_cflags]"
+set_board_info ldflags "[libgloss_link_flags] ${xldflags} [newlib_link_flags]"
 
 # No linker script needed.
 set_board_info ldscript ""
@@ -69,22 +70,22 @@ set_board_info gdb,noresults 1
 set_board_info gdb,noinferiorio 1
 set_board_info needs_status_wrapper ""
 
-if { $tool == "gdb" } {
-	# We use gdbserver to run applications
-	set_board_info use_gdb_stub 1
-	# GDB jumps to start_symbols after loading. Default value is `start'.
-	set_board_info gdb,start_symbol "__start"
-	set_board_info gdb,do_reload_on_run 1
-	# Hardware watchpoint are not precies on ARC - they may fire few
-	# instructions after ST instruction and this may skew testing when
-	# there is several ST to same address consequently, as first stores may
-	# get missed. Unfortunately it seems that GDB testsuite configuration
-	# doesn't distinguish between hardware watchpoints and breakpoint, the
-	# latter ones should work fine on ARC.
-	set_board_info gdb,no_hardware_watchpoints 1
-	# This duplicates the ones without 'gdb,'
-	set_board_info gdb,noargs 1
-	set_board_info gdb,nofileio 1
+if {$tool == "gdb"} {
+    # We use gdbserver to run applications
+    set_board_info use_gdb_stub 1
+    # GDB jumps to start_symbols after loading. Default value is `start'.
+    set_board_info gdb,start_symbol "__start"
+    set_board_info gdb,do_reload_on_run 1
+    # Hardware watchpoint are not precies on ARC - they may fire few
+    # instructions after ST instruction and this may skew testing when
+    # there is several ST to same address consequently, as first stores may
+    # get missed. Unfortunately it seems that GDB testsuite configuration
+    # doesn't distinguish between hardware watchpoints and breakpoint, the
+    # latter ones should work fine on ARC.
+    set_board_info gdb,no_hardware_watchpoints 1
+    # This duplicates the ones without 'gdb,'
+    set_board_info gdb,noargs 1
+    set_board_info gdb,nofileio 1
 }
 
 # vim: noexpandtab sts=4 ts=8:

--- a/dejagnu/baseboards/arc-linux-aa4.exp
+++ b/dejagnu/baseboards/arc-linux-aa4.exp
@@ -34,21 +34,21 @@ set_board_info username root
 set_board_info password ""
 
 # Set up telnet connection details.
-set_board_info shell_prompt          "\[^\r\n\]*# "
-set_board_info telnet_username       "root"
-set_board_info telnet_password       ""
-set_board_info telnet_exec_timeout   120
+set_board_info shell_prompt "\[^\r\n\]*# "
+set_board_info telnet_username "root"
+set_board_info telnet_password ""
+set_board_info telnet_exec_timeout 120
 
 # Set up FTP connection details.
-set_board_info ftp_username          root
-set_board_info ftp_password          "\'\'"
-set_board_info ftp_download_timeout  10
-set_board_info ftp_upload_timeout    10
+set_board_info ftp_username root
+set_board_info ftp_password "\'\'"
+set_board_info ftp_download_timeout 10
+set_board_info ftp_upload_timeout 10
 
 # This simulator isn't slow.
 set_board_info slow_simulator 0
 
-if { $tool == "gdb" } {
+if {$tool == "gdb"} {
     # IP address of target
     set_board_info sockethost "$env(ARC_TEST_ADDR_UCLIBC):"
 }

--- a/dejagnu/baseboards/arc-linux-generic.exp
+++ b/dejagnu/baseboards/arc-linux-generic.exp
@@ -34,7 +34,7 @@ set_board_info target_install ${target_triplet}
 # Load the generic configuration for this board. This will define a basic set
 # of routines needed by the tool to communicate with the board. Depends on the
 # tool.
-if { $tool == "gdb" } {
+if {$tool == "gdb"} {
     load_generic_config "gdbserver"
 } else {
     load_generic_config "unix"
@@ -54,8 +54,8 @@ set_board_info compiler [find_gcc]
 
 # Set up connection using telnet and FTP. Hostname, prompts, usernames and
 # passwords are in the board specific files.
-set_board_info connect        telnet
-set_board_info file_transfer  ftp
+set_board_info connect telnet
+set_board_info file_transfer ftp
 
 # We only support newlib on this target. We assume that all multilib
 # options have been specified before we get here.
@@ -64,7 +64,7 @@ set_board_info file_transfer  ftp
 set_board_info ldscript ""
 
 # Can't pass arguments to programs on this target..
-set_board_info noargs  1
+set_board_info noargs 1
 
 # Used by a few gcc.c-torture testcases to delimit how large the stack can
 # be.
@@ -75,13 +75,13 @@ set_board_info gcc,stack_size 65536
 # We can't do input in GDB (yet! HA!). It *will* do output, hurrah.
 set_board_info gdb,noinferiorio 1
 # Or pass arguments.
-set_board_info gdb,noargs  1
+set_board_info gdb,noargs 1
 # And there's no support for signals.
-set_board_info gdb,nosignals  1
+set_board_info gdb,nosignals 1
 # GDB can't return results
 set_board_info gdb,noresults 1
 
-if { $tool == "gdb" } {
+if {$tool == "gdb"} {
     # GDB specific setup to enable gdbserver on the target.
 
     # Use telnet as protocol to spawn gdbserver
@@ -93,23 +93,25 @@ if { $tool == "gdb" } {
     # No hardware watchpoints
     set_board_info gdb,no_hardware_watchpoints 1
     # The command to use
-    if { [info exists gdb_server_prog] } {
-	set_board_info gdb_server_prog $gdb_server_prog
+    if {[info exists gdb_server_prog]} {
+        set_board_info gdb_server_prog $gdb_server_prog
     } else {
-	set_board_info gdb_server_prog /bin/gdbserver
+        set_board_info gdb_server_prog /bin/gdbserver
     }
     # Use a GDB stub
     set_board_info use_gdb_stub 1
 
     # Set up sysroot. This is an option relating to the host running GDB, not
     # the board, hence the contortion.
-    if { [info exists env(ARC_GDB_COMMFILE)] } {
-	set board_info([get_local_hostname],gdb_opts) "-x $env(ARC_GDB_COMMFILE)"
-    } elseif { [info exists ::toolchain_sysroot_dir] } {
-	set board_info([get_local_hostname],gdb_opts) "-ex 'set sysroot $::toolchain_sysroot_dir'"
+    if {[info exists env(ARC_GDB_COMMFILE)]} {
+        set board_info([get_local_hostname],gdb_opts) \
+            "-x $env(ARC_GDB_COMMFILE)"
+    } elseif {[info exists ::toolchain_sysroot_dir]} {
+        set board_info([get_local_hostname],gdb_opts) \
+            "-ex 'set sysroot $::toolchain_sysroot_dir'"
     } else {
-	puts "Neither ARC_GDB_COMMFILE, not toolchain_sysroot_dir environment
-variables are specified. Some tests are likely to fail."
+        puts "Neither ARC_GDB_COMMFILE, not toolchain_sysroot_dir environment \
+            variables are specified. Some tests are likely to fail."
     }
 }
 

--- a/dejagnu/baseboards/arc-linux-qemu-user.exp
+++ b/dejagnu/baseboards/arc-linux-qemu-user.exp
@@ -35,18 +35,16 @@ search_and_load_file "library file" "arc-common.exp" ${boards_dir}
 process_multilib_options [arc_get_multilib_options]
 
 #set QEMU flags
-if ![info exists qemu_flags] {
+if {![info exists qemu_flags]} {
     set qemu_flags {}
 }
 
 # Select processor family.
-if { [check_target_archs] } {
-    lappend qemu_flags \
-	-cpu archs
+if {[check_target_archs]} {
+    lappend qemu_flags -cpu archs
     set qemu_arch "arc"
-} elseif { [check_target_arc64_64] } {
-    lappend qemu_flags \
-	-cpu hs6x
+} elseif {[check_target_arc64_64]} {
+    lappend qemu_flags -cpu hs6x
     set qemu_arch "arc64"
 } else {
     perror "Unknown CPU configuration"
@@ -56,7 +54,7 @@ set qemu_bin "$::env(QEMU_HOME)/bin/qemu-${qemu_arch}"
 
 set_board_info sim_time_limit 300
 # If we test libstdc++ increase the time.
-if { $tool == "libstdc++" } {
+if {$tool == "libstdc++"} {
     set_board_info sim_time_limit 1200
 }
 
@@ -64,7 +62,7 @@ if { $tool == "libstdc++" } {
 set_board_info sim "$qemu_bin [join $qemu_flags]"
 set_board_info is_simulator 1
 
-set_board_info compiler  "[find_gcc]"
+set_board_info compiler "[find_gcc]"
 
 # The simulator returns exit statuses
 set_board_info needs_status_wrapper ""

--- a/dejagnu/baseboards/arc-linux-qemu.exp
+++ b/dejagnu/baseboards/arc-linux-qemu.exp
@@ -28,7 +28,7 @@ send_user "ARC Linux test setup\n"
 search_and_load_file "library file" "arc-linux-generic.exp" ${boards_dir}
 
 # get the address of the host where qemu is running on
-if { [info exists ::env(ARC_TEST_ADDR_UCLIBC)] } {
+if {[info exists ::env(ARC_TEST_ADDR_UCLIBC)]} {
     set addr $env(ARC_TEST_ADDR_UCLIBC)
 } else {
     set addr 127.0.0.1
@@ -41,32 +41,32 @@ set_board_info username root
 set_board_info password ""
 
 # Set up telnet connection details.
-set_board_info shell_prompt          "\[^\r\n\]*# "
-set_board_info telnet_username       "root"
-set_board_info telnet_password       ""
-set_board_info telnet_exec_timeout   120
-if { [info exists ::env(TARGET_TELNET_PORT)] } {
-    set_board_info netport           $addr:$env(TARGET_TELNET_PORT)
+set_board_info shell_prompt "\[^\r\n\]*# "
+set_board_info telnet_username "root"
+set_board_info telnet_password ""
+set_board_info telnet_exec_timeout 120
+if {[info exists ::env(TARGET_TELNET_PORT)]} {
+    set_board_info netport $addr:$env(TARGET_TELNET_PORT)
 } else {
-    set_board_info netport           $addr:5556
+    set_board_info netport $addr:5556
 }
 
 
 # Set up FTP connection details.
-set_board_info ftp_username          root
-set_board_info ftp_password          "\'\'"
-set_board_info ftp_download_timeout  10
-set_board_info ftp_upload_timeout    10
-if { [info exists ::env(TARGET_FTP_PORT)] } {
-    set_board_info ftp_port          $env(TARGET_FTP_PORT)
+set_board_info ftp_username root
+set_board_info ftp_password "\'\'"
+set_board_info ftp_download_timeout 10
+set_board_info ftp_upload_timeout 10
+if {[info exists ::env(TARGET_FTP_PORT)]} {
+    set_board_info ftp_port $env(TARGET_FTP_PORT)
 } else {
-    set_board_info ftp_port          5555
+    set_board_info ftp_port 5555
 }
 
 # This simulator isn't slow.
 set_board_info slow_simulator 0
 
-if { $tool == "gdb" } {
+if {$tool == "gdb"} {
     # IP address of target
     set_board_info sockethost "$addr:"
 }

--- a/dejagnu/baseboards/arc-nsim.exp
+++ b/dejagnu/baseboards/arc-nsim.exp
@@ -49,8 +49,8 @@ search_and_load_file "library file" "arc-common.exp" ${boards_dir}
 
 # GDB tests require special treatment, they ignore "gdb-comm" configuration
 # unless "monitor" GDB test suite configuration is loaded.
-if { $tool == "gdb" } {
-	load_lib "../config/monitor.exp"
+if {$tool == "gdb"} {
+    load_lib "../config/monitor.exp"
 }
 
 # Use nSIM GNU IO hostlink
@@ -59,13 +59,15 @@ set_board_info arc,hostlink "nsim"
 # Any multilib options are set in an environment variable.
 process_multilib_options [arc_get_multilib_options]
 
-set xldflags "-Wl,--defsym=__DEFAULT_HEAP_SIZE=256m -Wl,--defsym=__DEFAULT_STACK_SIZE=1024m"
+set xldflags "-Wl,--defsym=__DEFAULT_HEAP_SIZE=256m \
+    -Wl,--defsym=__DEFAULT_STACK_SIZE=1024m"
 
 # We only support newlib on this target. We assume that all multilib
 # options have been specified before we get here.
-set_board_info compiler  "[find_gcc]"
-set_board_info cflags    "[libgloss_include_flags] [newlib_include_flags] [arc_get_cflags]"
-set_board_info ldflags   "[libgloss_link_flags] ${xldflags} [newlib_link_flags]"
+set_board_info compiler "[find_gcc]"
+set_board_info cflags \
+    "[libgloss_include_flags] [newlib_include_flags] [arc_get_cflags]"
+set_board_info ldflags "[libgloss_link_flags] ${xldflags} [newlib_link_flags]"
 
 # No linker script needed.
 set_board_info ldscript ""
@@ -84,7 +86,7 @@ lappend nsim_flags -reconnect
 # certain floating point tests in libstdc++ that take quite a lot of time to
 # execute with soft-FP - around 15 minutes on Xeon@3.5GHz host.  Enabling Turbo
 # reduces this time to mere 1 minute.
-if { $tool == "libstdc++" } {
+if {$tool == "libstdc++"} {
     spawn [board_info $::board nsim_exe] -on nsim_fast
     expect {
 	"Download failed: no file name specified" {
@@ -153,16 +155,16 @@ set_board_info gdb,noresults 1
 set_board_info gdb,noinferiorio 1
 set_board_info needs_status_wrapper ""
 
-if { $tool == "gdb" } {
-	# We use gdbserver to run applications
-	set_board_info use_gdb_stub 1
-	# GDB jumps to start_symbols after loading. Default value is `start'.
-	set_board_info gdb,start_symbol "__start"
-	set_board_info gdb,do_reload_on_run 1
-	set_board_info gdb,no_hardware_watchpoints 1
-	# This duplicates the one without 'gdb,'
-	set_board_info gdb,noargs 1
-	set_board_info gdb,nofileio 1
+if {$tool == "gdb"} {
+    # We use gdbserver to run applications
+    set_board_info use_gdb_stub 1
+    # GDB jumps to start_symbols after loading. Default value is `start'.
+    set_board_info gdb,start_symbol "__start"
+    set_board_info gdb,do_reload_on_run 1
+    set_board_info gdb,no_hardware_watchpoints 1
+    # This duplicates the one without 'gdb,'
+    set_board_info gdb,noargs 1
+    set_board_info gdb,nofileio 1
 }
 
 # Tests may recognize this board as a simulator and reduce amount
@@ -171,15 +173,15 @@ set_board_info is_simulator 1
 
 # Turn on support of compat.exp tests from GCC testsuite if environment
 # variable ARC_GCC_COMPAT_SUITE == 1.
-if { [info exists env(ARC_GCC_COMPAT_SUITE)] } {
+if {[info exists env(ARC_GCC_COMPAT_SUITE)]} {
     set is_gcc_compat_suite $env(ARC_GCC_COMPAT_SUITE)
 } else {
-    if { ![info exists is_gcc_compat_suite] } {
-	set is_gcc_compat_suite 0
+    if {![info exists is_gcc_compat_suite]} {
+        set is_gcc_compat_suite 0
     }
 }
 
-if { $is_gcc_compat_suite } {
+if {$is_gcc_compat_suite} {
     fix_gcc_compat_multilib_flags
 }
 

--- a/dejagnu/baseboards/arc-openocd.exp
+++ b/dejagnu/baseboards/arc-openocd.exp
@@ -27,8 +27,10 @@ set_board_info arc,openocd_log_level 0
 set_board_info arc,has_executable_stack 0
 
 # GDB test break-unload-file.exp does command "file", which resets gdbarch to
-# ARCompact one, which doesn't play well with OpenOCD when actual target is ARC v2.
-if { !([check_target_arc700] || [check_target_arc600] || [check_target_arc601]) } {
+# ARCompact one, which doesn't play well with OpenOCD when actual target is
+# ARC v2.
+if {!([check_target_arc700] || [check_target_arc600] || \
+        [check_target_arc601])} {
     set_board_info gdb_init_command "set arch ARCv2"
 }
 

--- a/dejagnu/baseboards/arc-sim-nsimdrv.exp
+++ b/dejagnu/baseboards/arc-sim-nsimdrv.exp
@@ -40,12 +40,12 @@ set xldflags "-Wl,--defsym=__DEFAULT_HEAP_SIZE=256m \
     -Wl,--defsym=__DEFAULT_STACK_SIZE=1024m"
 
 # Set common defaults
-if ![info exists nsim_flags] {
+if {![info exists nsim_flags]} {
     set nsim_flags {}
 }
 lappend nsim_flags \
-	-on nsim_isa_enable_timer_0 \
-	-on nsim_isa_enable_timer_1
+    -on nsim_isa_enable_timer_0 \
+    -on nsim_isa_enable_timer_1
 
 # Disable memory and instruction exceptions - execution will halt on error,
 # instead of generating exception that may not be properly handled.
@@ -63,20 +63,20 @@ set_board_info sim_time_limit 300
 # certain floating point tests in libstdc++ that take quite a lot of time to
 # execute with soft-FP - around 15 minutes on Xeon@3.5GHz host.  Enabling Turbo
 # reduces this time to mere 1 minute.
-if { $tool == "libstdc++" } {
-#    Disable nsim TURBO feature as it is buggy.
-#    spawn $nsim_bin -on nsim_fast
-#    expect {
-#	"Download failed: no file name specified" {
-#	    verbose "nSIM Turbo is available"
-#	    lappend nsim_flags -on nsim_fast
-#	}
-#	default {
-#	    # nSIM would spit out an error message if Turbo is not supported.
-#	    verbose "nSIM Turbo is not available, increasing timeout"
-	    set_board_info sim_time_limit 1200
-#	}
-#    }
+if {$tool == "libstdc++"} {
+    # Disable nsim TURBO feature as it is buggy.
+    #spawn $nsim_bin -on nsim_fast
+    #expect {
+    #    "Download failed: no file name specified" {
+    #        verbose "nSIM Turbo is available"
+    #        lappend nsim_flags -on nsim_fast
+    #    }
+    #    default {
+    #        # nSIM would spit out an error message if Turbo is not supported.
+    #        verbose "nSIM Turbo is not available, increasing timeout"
+    set_board_info sim_time_limit 1200
+    #    }
+    #    }
 }
 
 # Check if nsim_download_elf_sections option is required - whether nSIM version
@@ -103,10 +103,10 @@ if {![check_target_arcv]} {
 }
 
 # Hostlink library support
-if { [info exists env(ARC_HOSTLINK_LIBRARY)] } {
+if {[info exists env(ARC_HOSTLINK_LIBRARY)]} {
     set xldflags "$xldflags -Wl,--whole-archive $env(ARC_HOSTLINK_LIBRARY) \
         -Wl,--no-whole-archive"
-} elseif { [info exists env(ARC_NSIM_HOSTLINK)] } {
+} elseif {[info exists env(ARC_NSIM_HOSTLINK)]} {
     set_board_info arc,hostlink $env(ARC_NSIM_HOSTLINK)
 
     if {[board_info $board arc,hostlink] != "metaware" && \
@@ -120,100 +120,100 @@ if { [info exists env(ARC_HOSTLINK_LIBRARY)] } {
     set_board_info arc,hostlink "nsim"
 }
 
-if { [board_info $board arc,hostlink] == "metaware" } {
+if {[board_info $board arc,hostlink] == "metaware"} {
     lappend nsim_flags -prop=nsim_hlink_gnu_io_ext=1
-} elseif { [board_info $board arc,hostlink] == "nsim" } {
+} elseif {[board_info $board arc,hostlink] == "nsim"} {
     lappend nsim_flags -prop=nsim_emt=1
 }
 
 # Big-endian?
-if [ string match arceb-* $target_triplet ] {
+if {[ string match arceb-* $target_triplet ]} {
     lappend nsim_flags -on nsim_isa_big_endian
 }
 
 # Select processor family. Also set nsim_isa_sat, which is mandatory for GCC.
-if { [check_target_arc64_64] } {
+if {[check_target_arc64_64]} {
     lappend nsim_flags \
-	-p nsim_isa_family=arc64     \
-	-p nsim_isa_div_rem_option=2 \
-	-p nsim_isa_mpy_option=9     \
-	-p nsim_isa_mpy64=1	     \
-	-p nsim_isa_div64_option=1   \
-	-p nsim_isa_has_fp=1	     \
-	-p nsim_isa_fp_vec_option=1  \
-	-p nsim_isa_fp_hp_option=1   \
-	-p nsim_isa_fp_dp_option=1   \
-	-p nsim_isa_fp_div_option=1  \
-	-p nsim_isa_fp_num_regs=32   \
-	-p nsim_isa_unaligned_option=1
-} elseif { [check_target_arc64_32] } {
-    lappend nsim_flags		     \
-	-p nsim_isa_family=av3hs     \
-	-p nsim_isa_pc_size=32	     \
-	-p nsim_isa_addr_size=32     \
-	-p nsim_isa_swap_option=1    \
-	-p nsim_isa_bitscan_option=1 \
-	-p nsim_isa_div_rem_option=2 \
-	-p nsim_isa_mpy_option=9     \
-	-p nsim_isa_unaligned_option=1
-} elseif { [check_target_arc700] } {
+        -p nsim_isa_family=arc64 \
+        -p nsim_isa_div_rem_option=2 \
+        -p nsim_isa_mpy_option=9 \
+        -p nsim_isa_mpy64=1 \
+        -p nsim_isa_div64_option=1 \
+        -p nsim_isa_has_fp=1 \
+        -p nsim_isa_fp_vec_option=1 \
+        -p nsim_isa_fp_hp_option=1 \
+        -p nsim_isa_fp_dp_option=1 \
+        -p nsim_isa_fp_div_option=1 \
+        -p nsim_isa_fp_num_regs=32 \
+        -p nsim_isa_unaligned_option=1
+} elseif {[check_target_arc64_32]} {
+    lappend nsim_flags \
+        -p nsim_isa_family=av3hs \
+        -p nsim_isa_pc_size=32 \
+        -p nsim_isa_addr_size=32 \
+        -p nsim_isa_swap_option=1 \
+        -p nsim_isa_bitscan_option=1 \
+        -p nsim_isa_div_rem_option=2 \
+        -p nsim_isa_mpy_option=9 \
+        -p nsim_isa_unaligned_option=1
+} elseif {[check_target_arc700]} {
     # GCC requires multiplier for ARC 700.
     lappend nsim_flags \
-	-p nsim_isa_family=a700 \
-	-on nsim_isa_sat \
-	-on nsim_isa_mpy32
-} elseif { [check_target_quarkse_em] } {
+        -p nsim_isa_family=a700 \
+        -on nsim_isa_sat \
+        -on nsim_isa_mpy32
+} elseif {[check_target_quarkse_em]} {
     compile_quarkse_em_nsim_apex
     lappend nsim_flags \
-	-p nsim_isa_family=av2em \
-	-p nsim_isa_core=3 \
-	-p nsim_isa_mpy_option=3 \
-	-p nsim_isa_div_rem_option=2 \
-	-p nsim_isa_code_density_option=2 \
-	-prop=nsim_ext=$tmpdir/quarkse_em_fscmp.so \
-	-prop=nsim_ext=$tmpdir/quarkse_em_fsdiv.so \
-	-prop=nsim_ext=$tmpdir/quarkse_em_fsflt2i.so \
-	-prop=nsim_ext=$tmpdir/quarkse_em_fsi2flt.so \
-	-prop=nsim_ext=$tmpdir/quarkse_em_fssqrt.so \
-	-p nsim_isa_lpc_size=16 \
-	-p nsim_isa_spfp=compact \
-	-p nsim_isa_dpfp=compact
-} elseif { [check_target_quarkse2_em] } {
+        -p nsim_isa_family=av2em \
+        -p nsim_isa_core=3 \
+        -p nsim_isa_mpy_option=3 \
+        -p nsim_isa_div_rem_option=2 \
+        -p nsim_isa_code_density_option=2 \
+        -prop=nsim_ext=$tmpdir/quarkse_em_fscmp.so \
+        -prop=nsim_ext=$tmpdir/quarkse_em_fsdiv.so \
+        -prop=nsim_ext=$tmpdir/quarkse_em_fsflt2i.so \
+        -prop=nsim_ext=$tmpdir/quarkse_em_fsi2flt.so \
+        -prop=nsim_ext=$tmpdir/quarkse_em_fssqrt.so \
+        -p nsim_isa_lpc_size=16 \
+        -p nsim_isa_spfp=compact \
+        -p nsim_isa_dpfp=compact
+} elseif {[check_target_quarkse2_em]} {
     compile_quarkse_em_nsim_apex
     lappend nsim_flags \
-	-p nsim_isa_family=av2em \
-	-p nsim_isa_core=3 \
-	-p nsim_isa_mpy_option=2 \
-	-p nsim_isa_div_rem_option=2 \
-	-p nsim_isa_code_density_option=2 \
-	-prop=nsim_ext=$tmpdir/quarkse_em_fsdiv.so \
-	-prop=nsim_ext=$tmpdir/quarkse_em_fssqrt.so
-} elseif { [check_target_arc600] } {
+        -p nsim_isa_family=av2em \
+        -p nsim_isa_core=3 \
+        -p nsim_isa_mpy_option=2 \
+        -p nsim_isa_div_rem_option=2 \
+        -p nsim_isa_code_density_option=2 \
+        -prop=nsim_ext=$tmpdir/quarkse_em_fsdiv.so \
+        -prop=nsim_ext=$tmpdir/quarkse_em_fssqrt.so
+} elseif {[check_target_arc600]} {
     lappend nsim_flags \
-	-p nsim_isa_family=a600 \
-	-p nsim_isa_core=6 \
-	-on nsim_isa_sat
-} elseif { [check_target_arc601] } {
+        -p nsim_isa_family=a600 \
+        -p nsim_isa_core=6 \
+        -on nsim_isa_sat
+} elseif {[check_target_arc601]} {
     lappend nsim_flags \
-	-p nsim_isa_family=a601 \
-	-p nsim_isa_core=6 \
-	-on nsim_isa_sat
-} elseif { [check_target_archs] } {
+        -p nsim_isa_family=a601 \
+        -p nsim_isa_core=6 \
+        -on nsim_isa_sat
+} elseif {[check_target_archs]} {
     lappend nsim_flags \
-	-p nsim_isa_family=av2hs \
-	-p nsim_isa_core=3 \
-	-on nsim_isa_sat
+        -p nsim_isa_family=av2hs \
+        -p nsim_isa_core=3 \
+        -on nsim_isa_sat
     # Assume the SQRT is defined when we use DSP extensions
-    if { [check_target_arc "__ARC_DSP__"] == 1 } {
-	lappend nsim_flags \
-	    -p nsim_isa_dsp_divsqrt_option=2 \
-	    -p nsim_isa_dsp_wide_option=1
+    if {[check_target_arc "__ARC_DSP__"] == 1} {
+        lappend nsim_flags \
+            -p nsim_isa_dsp_divsqrt_option=2 \
+            -p nsim_isa_dsp_wide_option=1
     }
-} elseif { [check_target_arcem] } {
+} elseif {[check_target_arcem]} {
     lappend nsim_flags \
-	-p nsim_isa_family=av2em \
-	-p nsim_isa_core=3 \
-	-on nsim_isa_sat
+        -p nsim_isa_family=av2em \
+        -p nsim_isa_core=3 \
+        -on nsim_isa_sat
 } elseif {[check_target_arcv]} {
     set ext "-all.i.zicsr.zifencei.zihintpause.b.zca.zcb.zcmp.zcmt.a.m.zbb"
     lappend nsim_flags \
@@ -279,13 +279,13 @@ set nsim_gcc_mapping {
 }
 
 foreach {gcc_define set_if_defined nsim_prop} $nsim_gcc_mapping {
-    if { [check_target_arc $gcc_define] == $set_if_defined } {
-	lappend nsim_flags -p $nsim_prop
+    if {[check_target_arc $gcc_define] == $set_if_defined} {
+        lappend nsim_flags -p $nsim_prop
     }
 }
 
 # Allow user to specify additional options, like JIT, etc.
-if { [info exists env(ARC_NSIM_OPTS) ] } {
+if {[info exists env(ARC_NSIM_OPTS) ]} {
     lappend nsim_flags $env(ARC_NSIM_OPTS)
 }
 
@@ -302,25 +302,26 @@ set_board_info needs_status_wrapper 1
 
 # Turn on support of compat.exp tests from GCC testsuite if environment
 # variable ARC_GCC_COMPAT_SUITE == 1.
-if { [info exists env(ARC_GCC_COMPAT_SUITE)] } {
+if {[info exists env(ARC_GCC_COMPAT_SUITE)]} {
     set_board_info arc,is_gcc_compat_suite $env(ARC_GCC_COMPAT_SUITE)
 } else {
-    if { ![board_info $board exists arc,is_gcc_compat_suite] } {
-	set_board_info arc,is_gcc_compat_suite 0
+    if {![board_info $board exists arc,is_gcc_compat_suite]} {
+        set_board_info arc,is_gcc_compat_suite 0
     }
 }
 
 # We only support newlib on this target. We assume that all multilib
 # options have been specified before we get here.
-set_board_info compiler  "[find_gcc]"
-set_board_info cflags    "[libgloss_include_flags] [newlib_include_flags] [arc_get_cflags]"
-set_board_info ldflags   "[libgloss_link_flags] ${xldflags} [newlib_link_flags]"
+set_board_info compiler "[find_gcc]"
+set_board_info cflags \
+    "[libgloss_include_flags] [newlib_include_flags] [arc_get_cflags]"
+set_board_info ldflags "[libgloss_link_flags] ${xldflags} [newlib_link_flags]"
 
 # No linker script needed.
 set_board_info ldscript ""
 
 # Metaware hostlink can return values.
-if { [board_info $board arc,hostlink] == "metaware" } {
+if {[board_info $board arc,hostlink] == "metaware"} {
     set_board_info gdb,noresults 0
 } else {
     set_board_info gdb,noresults 1
@@ -330,7 +331,7 @@ set_board_info noargs 1
 set_board_info gdb,nosignals 1
 set_board_info gdb,noinferiorio 1
 
-if [string is true -strict [board_info $board arc,is_gcc_compat_suite]] {
+if {[string is true -strict [board_info $board arc,is_gcc_compat_suite]]} {
     fix_gcc_compat_multilib_flags
 }
 

--- a/dejagnu/baseboards/arc-sim-qemu.exp
+++ b/dejagnu/baseboards/arc-sim-qemu.exp
@@ -38,34 +38,30 @@ set xldflags "--specs=nsim.specs -Wl,--defsym=__DEFAULT_HEAP_SIZE=256m \
     -Wl,--defsym=__DEFAULT_STACK_SIZE=32m"
 
 #set QEMU flags
-if ![info exists qemu_flags] {
+if {![info exists qemu_flags]} {
     set qemu_flags {}
 }
 
 # Select processor family.
-if { [check_target_archs] } {
-    lappend qemu_flags \
-	-cpu archs
+if {[check_target_archs]} {
+    lappend qemu_flags -cpu archs
     set qemu_arch "arc"
-} elseif { [check_target_arcem] } {
-    lappend qemu_flags \
-	-cpu arcem
+} elseif {[check_target_arcem]} {
+    lappend qemu_flags -cpu arcem
     set qemu_arch "arc"
-} elseif { [check_target_arc64_64] } {
-    lappend qemu_flags \
-	-cpu hs6x
+} elseif {[check_target_arc64_64]} {
+    lappend qemu_flags -cpu hs6x
     set qemu_arch "arc64"
-} elseif { [check_target_arc64_32] } {
-    lappend qemu_flags \
-	-cpu hs5x
+} elseif {[check_target_arc64_32]} {
+    lappend qemu_flags -cpu hs5x
     set qemu_arch "arc"
 } else {
     perror "Unknown CPU configuration"
 }
 
 # Check if we want a semihosting run
-if ![info exists qemu_serial_io] {
-    lappend qemu_flags  -semihosting
+if {![info exists qemu_serial_io]} {
+    lappend qemu_flags -semihosting
 } else {
     lappend qemu_flags -serial stdio
 }
@@ -77,7 +73,7 @@ set qemu_bin "$::env(QEMU_HOME)/bin/qemu-system-${qemu_arch}"
 
 set_board_info sim_time_limit 300
 # If we test libstdc++ increase the time.
-if { $tool == "libstdc++" } {
+if {$tool == "libstdc++"} {
     set_board_info sim_time_limit 1200
 }
 
@@ -85,9 +81,9 @@ if { $tool == "libstdc++" } {
 set_board_info sim "$qemu_bin [join $qemu_flags]"
 set_board_info is_simulator 1
 
-set_board_info compiler  "[find_gcc]"
-set_board_info cflags    "[libgloss_include_flags] [newlib_include_flags]"
-set_board_info ldflags   "[libgloss_link_flags] ${xldflags} [newlib_link_flags]"
+set_board_info compiler "[find_gcc]"
+set_board_info cflags "[libgloss_include_flags] [newlib_include_flags]"
+set_board_info ldflags "[libgloss_link_flags] ${xldflags} [newlib_link_flags]"
 # No linker script needed.
 set_board_info ldscript ""
 

--- a/dejagnu/baseboards/arc-sim.exp
+++ b/dejagnu/baseboards/arc-sim.exp
@@ -46,13 +46,15 @@ setup_sim arc
 process_multilib_options [arc_get_multilib_options]
 
 # Extra link flags specific to ARC
-set xldflags "-Wl,--defsym=__DEFAULT_HEAP_SIZE=256m -Wl,--defsym=__DEFAULT_STACK_SIZE=32m"
+set xldflags "-Wl,--defsym=__DEFAULT_HEAP_SIZE=256m \
+    -Wl,--defsym=__DEFAULT_STACK_SIZE=32m"
 
 # We only support newlib on this target. We assume that all multilib
 # options have been specified before we get here.
-set_board_info compiler  "[find_gcc]"
-set_board_info cflags    "[libgloss_include_flags] [newlib_include_flags] [arc_get_cflags]"
-set_board_info ldflags   "[libgloss_link_flags] ${xldflags} [newlib_link_flags]"
+set_board_info compiler "[find_gcc]"
+set_board_info cflags \
+    "[libgloss_include_flags] [newlib_include_flags] [arc_get_cflags]"
+set_board_info ldflags "[libgloss_link_flags] ${xldflags} [newlib_link_flags]"
 # No linker script needed.
 set_board_info ldscript ""
 

--- a/dejagnu/baseboards/arc64-dummy.exp
+++ b/dejagnu/baseboards/arc64-dummy.exp
@@ -38,7 +38,7 @@ set xldflags ""
 set cflags "-static"
 
 #set QEMU flags
-if ![info exists qemu_flags] {
+if {![info exists qemu_flags]} {
     set qemu_flags {}
 }
 
@@ -50,9 +50,9 @@ set_board_info is_simulator 1
 # No multilib options needed by default.
 process_multilib_options ""
 
-set_board_info compiler  "[find_gcc]"
-set_board_info cflags    "[libgloss_include_flags] [newlib_include_flags]"
-set_board_info ldflags   "[libgloss_link_flags] ${xldflags} [newlib_link_flags]"
+set_board_info compiler "[find_gcc]"
+set_board_info cflags "[libgloss_include_flags] [newlib_include_flags]"
+set_board_info ldflags "[libgloss_link_flags] ${xldflags} [newlib_link_flags]"
 # No linker script needed.
 set_board_info ldscript ""
 

--- a/dejagnu/baseboards/arc64-nsim.exp
+++ b/dejagnu/baseboards/arc64-nsim.exp
@@ -34,10 +34,11 @@ search_and_load_file "library file" "arc-common.exp" ${boards_dir}
 # Any multilib options are set in an environment variable.
 #process_multilib_options [arc_get_multilib_options]
 
-set xldflags "-Wl,--defsym=__DEFAULT_HEAP_SIZE=256m -Wl,--defsym=__DEFAULT_STACK_SIZE=1024m"
+set xldflags "-Wl,--defsym=__DEFAULT_HEAP_SIZE=256m \
+    -Wl,--defsym=__DEFAULT_STACK_SIZE=1024m"
 
 #set QEMU flags
-if ![info exists qemu_flags] {
+if {![info exists qemu_flags]} {
     set qemu_flags {}
 }
 
@@ -49,9 +50,10 @@ set_board_info is_simulator 1
 # No multilib options needed by default.
 process_multilib_options ""
 
-set_board_info compiler  "[find_gcc]"
-set_board_info cflags    "--specs=nsim.specs [libgloss_include_flags] [newlib_include_flags]"
-set_board_info ldflags   "[libgloss_link_flags] ${xldflags} [newlib_link_flags]"
+set_board_info compiler "[find_gcc]"
+set_board_info cflags \
+    "--specs=nsim.specs [libgloss_include_flags] [newlib_include_flags]"
+set_board_info ldflags "[libgloss_link_flags] ${xldflags} [newlib_link_flags]"
 # No linker script needed.
 set_board_info ldscript ""
 

--- a/dejagnu/baseboards/arc64-qemu.exp
+++ b/dejagnu/baseboards/arc64-qemu.exp
@@ -38,13 +38,13 @@ set xldflags "--specs=nsim.specs -Wl,--defsym=__DEFAULT_HEAP_SIZE=256m \
     -Wl,--defsym=__DEFAULT_STACK_SIZE=32m"
 
 #set QEMU flags
-if ![info exists qemu_flags] {
+if {![info exists qemu_flags]} {
     set qemu_flags {}
 }
 
 lappend qemu_flags \
-    -M arc-sim -cpu hs6x -m 2G -nographic -no-reboot -monitor none -semihosting\
-    -kernel
+    -M arc-sim -cpu hs6x -m 2G -nographic -no-reboot -monitor none \
+    -semihosting -kernel
 
 set qemu_wrapper "$::env(QEMU_HOME)/bin/qemu-system-arc64"
 
@@ -53,9 +53,9 @@ set_board_info sim "$qemu_wrapper [join $qemu_flags]"
 set_board_info sim_time_limit 15
 set_board_info is_simulator 1
 
-set_board_info compiler  "[find_gcc]"
-set_board_info cflags    "[libgloss_include_flags] [newlib_include_flags]"
-set_board_info ldflags   "[libgloss_link_flags] ${xldflags} [newlib_link_flags]"
+set_board_info compiler "[find_gcc]"
+set_board_info cflags "[libgloss_include_flags] [newlib_include_flags]"
+set_board_info ldflags "[libgloss_link_flags] ${xldflags} [newlib_link_flags]"
 # No linker script needed.
 set_board_info ldscript ""
 

--- a/dejagnu/nsim-extra.exp
+++ b/dejagnu/nsim-extra.exp
@@ -27,17 +27,17 @@ proc nsim_close {} {
     verbose "nsim_close" 3
 
     # Close nSim if it is running
-    if [board_info $board exists nsim_id] {
-	set nsim_id [board_info $board nsim_id]
-	if [catch {close -i $nsim_id}] {
-	    verbose "nsim_close: failed to close $nsim_id: $errorInfo"
-	}
+    if {[board_info $board exists nsim_id]} {
+        set nsim_id {[board_info $board nsim_id]}
+        if {[catch {close -i $nsim_id}]} {
+            verbose "nsim_close: failed to close $nsim_id: $errorInfo"
+        }
 
-	if [catch {wait -i $nsim_id}] {
-	    verbose "nsim_close: failed to wait for $nsim_id: $errorInfo"
-	}
+        if {[catch {wait -i $nsim_id}]} {
+            verbose "nsim_close: failed to wait for $nsim_id: $errorInfo"
+        }
 
-	unset_board_info nsim_id
+        unset_board_info nsim_id
     }
 }
 
@@ -62,10 +62,14 @@ proc nsim_open { portnum } {
     # null from Expect, so we have to use a shell to help as here.
 
     # Use either TCF or props file. TCF has higher priority.
-    if [info exists env(ARC_NSIM_TCF)] {
-	spawn sh -c "[board_info $board nsim_exe] -port $portnum -tcf $env(ARC_NSIM_TCF) [join [board_info $board nsim_flags]] >/dev/null 2>/dev/null"
+    if {[info exists env(ARC_NSIM_TCF)]} {
+        spawn sh -c "[board_info $board nsim_exe] -port $portnum \
+            -tcf $env(ARC_NSIM_TCF) \
+            [join [board_info $board nsim_flags]] >/dev/null 2>/dev/null"
     } else {
-	spawn sh -c "[board_info $board nsim_exe] -port $portnum -propsfile '$env(ARC_NSIM_PROPS)' [join [board_info $board nsim_flags]] >/dev/null 2>/dev/null"
+        spawn sh -c "[board_info $board nsim_exe] -port $portnum \
+            -propsfile '$env(ARC_NSIM_PROPS)' \
+            [join [board_info $board nsim_flags]] >/dev/null 2>/dev/null"
     }
     unset_board_info nsim_id
     set_board_info nsim_id $spawn_id
@@ -91,8 +95,8 @@ proc arc-nsim_reboot { connhost args } {
     verbose "arc-nsim_reboot $connhost $args" 3
 
     # Do we have board?
-    if {! [info exists board]} {
-	set board $connhost
+    if {![info exists board]} {
+        set board $connhost
     }
 
     # GDB testsuite has an unfortunate trait - it reboots target after


### PR DESCRIPTION
This PR fix all stylistic and functional errors of dejagnu scripts. Besides that, PR includes itself a Tcl linter to CI for dejagnu scripts related to ARC and nSIM to avoid such errors in the future. This linter matches with [GNU Coding Standards (Chapter 5)](http://www.literateprogramming.com/gnustandards.pdf).