### PR TITLE
Update arc-release branch for arc-2024.06 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,15 @@ And now, when all the preparations are done, it's required only to start build p
 ./ct-ng build
 ```
 
+> :warning: There is set of samples which correspond to
+> native toolchains. Such toolchains are used inside of ARC targets.
+> If you want to build a native toolchain then a corresponding
+> cross-toolchain must be presented in `PATH`. E.g., if you want to
+> build `snps-arc64-snps-native-gnu` sample for a native toolchain
+> then you need to build `snps-arc64-snps-linux-gnu` sample for
+> a cross-compiler first and add `bin` directory of this cross-compiler
+> to `PATH`.
+
 ## Building toolchain for Windows
 
 ### Preparation for building ARC cross-toolchain for Windows host

--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ While the top of *development* branches should build and run reliably, there
 is no guarantee of this. Users who encountered an error are welcomed to create
 a new bug report at GitHub Issues for this `toolchain` project.
 
+## Documentation
+
+There are several documentation sites for ARC GNU toolchain:
+
+1. [GNU toolchain documentation site](https://foss-for-synopsys-dwc-arc-processors.github.io/documentation) - the documentation site for ARC Classic targets.
+2. [ARC-V Processors Getting Started](https://foss-for-synopsys-dwc-arc-processors.github.io/arc-v-getting-started) - the documentation for ARC-V targets.
+3. [Old GNU toolchain documentation site](https://foss-for-synopsys-dwc-arc-processors.github.io/toolchain/) - the documentation site for ARC Classic targets
+for release 2023.03 and earlier.
+
 ## Build environment
 
 The toolchain building is being done by [Crosstool-NG](https://github.com/crosstool-ng/crosstool-ng)
@@ -211,6 +220,8 @@ The following pre-defined configurations (they are called "samples" on Crosstool
 1. `snps-arc64-snps-linux-gnu` - Linux glibc cross-toolchain for for ARC HS6x processors for 64-bit Linux hosts
 1. `snps-arc64-snps-native-gnu` -  Linux glibc "native" toolchain from ARC HS6x processors
 1. `snps-arc64-unknown-elf` - Bare-metal cross-toolchain for ARC HS6x processors for 64-bit Linux hosts
+1. `snps-riscv64-unknown-elf` - Bare-metal cross-toolchain for ARC-V processors for 64-bit Linux hosts
+1. `snps-riscv64-win-elf` - Bare-metal cross-toolchain for ARC-V processors for 64-bit Windows hosts
 
 And to get Crosstool-NG configured with either of those samples just say: `./ct-ng sample_name`. For example, to get bare-metal toolchain for ARCompact/ARCv2 processors say: `./ct-ng snps-arc-multilib-elf32`.
 
@@ -225,9 +236,9 @@ and make all the settings manually. For that just say `./ct-ng menuconfig` and u
 
 The most interesting options for toolchain users might be:
 
-* Selection of the default target CPU model. To change it go to `Target options -> Emit assembly for CPU` and specify one of the possible values for GCC's `-mcpu` option, see <https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/wiki/Understanding-GCC-mcpu-option> for the reference.
-* Selection of ARC64 processors. For that go to  `Target options -> Bitness` and select `64-bit`.
-* `CFLAGS` to be used for compilation of libraries for the target. Those might be set in  `Target options -> Target CFLAGS`.
+* Selection of the default target CPU model. To change it go to `Target options -> Emit assembly for CPU` and specify one of the possible values for GCC's `-mcpu` option (refer to [documentation](https://foss-for-synopsys-dwc-arc-processors.github.io/documentation/2024.06/toolchain/target-options/) for details).
+* Selection of ARC64 processors. For that go to `Target options -> Bitness` and select `64-bit`.
+* `CFLAGS` to be used for compilation of libraries for the target. Those might be set in `Target options -> Target CFLAGS`.
 
 ## Building a toolchain with Crosstool-NG
 
@@ -322,9 +333,14 @@ Prefixes which start with `arc-` correspond to little endian toolchains. Prefixe
 `arceb-elf32-gdb`. However, big endian tools are not available for ARCv3 yet.
 
 You can find more information about variants of toolchains, `-mcpu` values
-and matching TCF files in [ARC Toolchain Variants](https://foss-for-synopsys-dwc-arc-processors.github.io/toolchain/baremetal/gcc-mcpu.html) page.
+and matching TCF files on [Toolchains for ARC Processors](https://foss-for-synopsys-dwc-arc-processors.github.io/documentation/2024.06/toolchain/) page.
 
 ### Using nSIM simulator to run bare metal ARC applications
+
+> Refer to [nSIM](https://foss-for-synopsys-dwc-arc-processors.github.io/documentation/2024.06/simulators/nsim/)
+> page of the documentation for details. Refer to
+> [GNU tools for ARC-V](https://foss-for-synopsys-dwc-arc-processors.github.io/arc-v-getting-started/synopsys-tools/gnu.html)
+> for details regarding running ARC-V applications on simulators.
 
 nSIM simulator supports GNU IO hostlink used by the libc library of bare metal
 GNU toolchain for ARC. nSIM option `nsim_emt=1` enables GNU IO hostlink. nSIM
@@ -404,25 +420,24 @@ developing for hardware platform which doesn't have hostlink support is that
 while `exit` functions `nosys.specs` is an infinite loop. For more details
 please see [documentation](https://foss-for-synopsys-dwc-arc-processors.github.io/toolchain/baremetal/index.html).
 
-### Using EM Starter Kit to run bare metal ARC EM application
+### Using HS Development Kit to run bare metal applications
 
-> A custom linker script is required to link applications for EM Starter Kit.
-> Refer to the section "Building an application" of our EM Starter Kit page:
-> <https://foss-for-synopsys-dwc-arc-processors.github.io/toolchain/baremetal/em-starter-kit.html>
-
-Build instructions for OpenOCD are available at its page:
-<https://github.com/foss-for-synopsys-dwc-arc-processors/openocd/blob/arc-2021.09/doc/README.ARC>
+> Refer to [Getting OpenOCD](https://foss-for-synopsys-dwc-arc-processors.github.io/documentation/2024.06/platforms/get-openocd/)
+> and [Using OpenOCD](https://foss-for-synopsys-dwc-arc-processors.github.io/documentation/2024.06/platforms/use-openocd/)
+> pages of the documentation for details regarding OpenOCD. Refer to
+> [Baremetal Targets](https://foss-for-synopsys-dwc-arc-processors.github.io/documentation/2024.06/baremetal/)
+> regarding building and running applications on boards.
 
 To run OpenOCD:
 
 ```shell
-openocd -f /usr/local/share/openocd/scripts/board/snps_em_sk_v2.3.cfg
+openocd -f board/snps_hsdk.cfg
 ```
 
 Compile test application and run:
 
 ```shell
-$ arc-elf32-gcc -mcpu=em4_dmips -g --specs=emsk_em9d.specs simple.c
+$ arc-elf32-gcc -mcpu=hs38_linux -specs=hsdk.specs -g simple.c
 $ arc-elf32-gdb --quiet a.out
 (gdb) target remote :3333
 (gdb) load
@@ -434,66 +449,6 @@ $ arc-elf32-gdb --quiet a.out
 (gdb) continue
 (gdb) quit
 ```
-
-### Using Ashling Opella-XD debug probe to debug bare metal applications
-
-> A custom linker script is required to link applications for EM Starter Kit.
-> Refer to the section "Building an application" of our EM Starter Kit page:
-> <https://foss-for-synopsys-dwc-arc-processors.github.io/toolchain/baremetal/em-starter-kit.html>
-> For different hardware configurations other changes might be required.
->
-> The Ashling Opella-XD debug probe and its drivers are not part of the GNU
-> tools distribution and should be obtained separately.
-
-The Ashling Opella-XD drivers distribution contains gdbserver for GNU toolchain.
-Command to start it:
-
-```shell
-$ ./ash-arc-gdb-server --jtag-frequency 8mhz --device arc \
-    --arc-reg-file <core.xml>
-```
-
-Where <core.xml> is a path to XML file describing AUX registers of target core.
-The Ashling drivers distribution contain files for ARC 600 (arc600-core.xml)
-and ARC 700 (arc700-core.xml). However due to recent changes in GDB with
-regards of support of XML target descriptions those files will not work out of
-the box, as order of some registers changed. To use Ashling GDB server with GDB
-starting from 2015.06 release, it is required to use modified files that can be
-found in this `toolchain` repository in `extras/opella-xd` directory.
-
-*Before* connecting GDB to an Opella-XD gdbserver it is essential to specify
-path to XML target description file that is aligned to `<core.xml>` file passed
-to GDB server. All registers described in `<core.xml>` also must be described
-in XML target description file in the same order. Otherwise GDB will not
-function properly.
-
-```shell
-(gdb) set tdesc filename <path/to/opella-CPU-tdesc.xml>
-```
-
-XML target description files are provided in the same `extras/opella-xd`
-directory as Ashling GDB server core files.
-
-Then connect to the target as with the OpenOCD/Linux gdbserver. For example a
-full session with an Opella-XD controlling an ARC EM target could start as
-follows:
-
-```shell
-$ arc-elf32-gcc -mcpu=arcem -g --specs=nsim.specs simple.c
-$ arc-elf32-gdb --quiet a.out
-(gdb) set tdesc filename toolchain/extras/opella-xd/opella-arcem-tdesc.xml
-(gdb) target remote :2331
-(gdb) load
-(gdb) break main
-(gdb) continue
-(gdb) break exit
-(gdb) continue
-# Register R0 contains exit code of function main()
-(gtb) info reg r0
-(gdb) quit
-```
-
-Similar to OpenOCD hostlink is not available in GDB with Ashling Opella-XD.
 
 ### Debugging applications on Linux for ARC
 

--- a/README.md
+++ b/README.md
@@ -321,6 +321,9 @@ Prefixes which start with `arc-` correspond to little endian toolchains. Prefixe
 `arceb-` correspond to big endian toolchains. E.g., GDB for big endian ARCv2 baremetal toolchain is
 `arceb-elf32-gdb`. However, big endian tools are not available for ARCv3 yet.
 
+You can find more information about variants of toolchains, `-mcpu` values
+and matching TCF files in [ARC Toolchain Variants](https://foss-for-synopsys-dwc-arc-processors.github.io/toolchain/baremetal/gcc-mcpu.html) page.
+
 ### Using nSIM simulator to run bare metal ARC applications
 
 nSIM simulator supports GNU IO hostlink used by the libc library of bare metal

--- a/arc-init.sh
+++ b/arc-init.sh
@@ -599,7 +599,6 @@ build_ncurses() {
 # Helper to build gmp, used by native gdb.  Starting from
 # GDB 11.1, it requires libgmp to be built natively [1].
 # Arguments:
-#   $1 - target triplet
 #
 # [1] gdb: Make GMP a required dependency for buidling GDB
 # https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=1b4ac058f7d
@@ -627,6 +626,137 @@ build_gmp() {
 	--enable-static
     make_target building
     make_target_ordered installing install DESTDIR=$SYSROOTDIR
+}
+
+# Helper to build mpfr, used by native gdb.  Since 21-Dec-2022,
+# GDB requires libgmp to be built natively [1].
+#
+# To build mpfr, native libgmp must have already bin built.  See
+# build_gmp() for that matter.
+#
+# [1] Use toplevel configure for GMP and MPFR for gdb
+# https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=991180627851
+#
+# Note:
+# libmpfr must be built against the native libgmp (--with-libgmp...).
+# If this libgmp is built for a sysroot (--prefix=/usr), then its libtool
+# script (libgmp.la) contains entries that can be confused with the build
+# system's paths:
+#
+# $ cat /sysroot/usr/lib/libgmp.a
+#   ...
+#   libdir=/usr/lib
+#
+# libtool has a trick to handle these situations, when the effective
+# compiler's prefix is not the same as the default one in build system.
+# to trigger this trick, one has to pass "--with-sysroot=yes" to the
+# configure command [2].  This will result in a successful build AND
+# a leading '=' character in some of the libraries names in installed
+# libmpfs.la script.  This leading character must be ignored on a native
+# system.  However on a build system, it must be exapnded to the full
+# sysroot path.  libtool >= 2.4.x is capable of doing this.
+#
+# [2]
+# https://bugs.gentoo.org/show_bug.cgi?id=521184#c8
+build_mpfr() {
+    local triplet=$1
+    mpfr_version=4.2.1
+    mpfr_url_base=https://www.mpfr.org/mpfr-current
+    mpfr_tar=mpfr-${mpfr_version}.tar.xz
+    mpfr_url=$mpfr_url_base/$mpfr_tar
+
+    mkdir -p $toolchain_build_dir/_download_tmp
+    cd $toolchain_build_dir/_download_tmp
+    if [ ! -s $mpfr_tar ]; then
+	$WGET -O $mpfr_tar $mpfr_url
+    fi
+
+    build_dir_init mpfr
+    tar xf $toolchain_build_dir/_download_tmp/$mpfr_tar --strip-components=1
+
+    configure_for_arc . $triplet \
+	--prefix=/usr \
+	--sysconfdir=/etc \
+	--localstatedir=/var \
+	--program-prefix= \
+	--enable-static \
+	--with-sysroot=yes \
+	--with-gmp=$SYSROOTDIR/usr
+
+    make_target building
+    make_target_ordered installing install DESTDIR=$SYSROOTDIR
+}
+
+# This function manipulates two entries. First, it turns
+#
+#   dependency_libs=' -L=/usr/lib =/usr/lib/libgmp.la'
+#
+# into
+#
+#   #dependency_libs=' -L=/usr/lib =/usr/lib'
+#   dependency_libs=' -L/sysroot/usr/lib /sysroot/usr/lib/libgmp.la'
+#
+# And then
+#
+#   libdir='/usr/lib'
+#
+# into
+#
+#   #libdir='/usr/lib'
+#   libdir='/sysroot/usr/lib'
+#
+# Rationale
+# ---------
+# libmpfr, which is needed for building gdb, installs with a libtool
+# script (*.la) with the following entry:
+#
+# $ cat /sysroot/usr/lib/libmpfr.la
+#   ...
+#   dependency_libs=' -L=/usr/lib =/usr/lib/libgmp.la'
+#
+# The leading '=' character indicates to libtool that this is a
+# sysroot path and must be replaced with whatever the compiler returns
+# as the sysroot: arc-snps-linux-gnu-gcc --print-sysroot
+#
+# libtool v2.2.7 that ships with GDB is not recent enough (v2.4+) to
+# expand these.  Therefore, this function will expand those pesky equal
+# signs.  Same sort of story goes for 'libdir'.  libtool 2.4+ provides
+# a "func_resolve_sysroot()" that turns "/usr/lib" into full path on a
+# build machine.
+la_expand_libs() {
+	local la_file="$1"
+
+	# Duplicate the "dependency_libs=" line while
+	# keeping the original instance commented out
+	$SED -i "s/^\(dependency_libs=.*\)/#\1\n\1/" $la_file
+
+	# The '=' in '-L=.* should be replaced by SYSROOTDIR
+	# The '=' in ' =/usr/lib/.*' should be replaced by SYSROOTDIR
+	$SED -i \
+	    -e "/^dependency_libs=/ s,-L=,-L$SYSROOTDIR,g" \
+	    -e "/^dependency_libs=/ s, =, $SYSROOTDIR,g" \
+	    $la_file
+
+        # Duplicate the "libdir=" line ...
+	$SED -i "s/^\(libdir=.*\)/#\1\n\1/" $la_file
+
+        # Add SYSROOTDIR to the beginning of the path in "libdir"
+	$SED -i "/^libdir=/ s,=',='$SYSROOTDIR," $la_file
+}
+
+# Remove the manipulated paths and uncomment the original ones.
+la_restore_libs() {
+	local la_file="$1"
+
+	$SED -i \
+	    -e "/^dependency_libs=/d" \
+	    -e "s/^#\(dependency_libs=.*\)/\1/" \
+	    $la_file
+
+	$SED -i \
+	    -e "/^libdir=/d" \
+	    -e "s/^#\(libdir=.*\)/\1/" \
+	    $la_file
 }
 
 # $1 - a configuration file or a directory with .config

--- a/build-glibc.sh
+++ b/build-glibc.sh
@@ -437,8 +437,11 @@ echo "  finished creating symlinks"
 if [ $DO_NATIVE_GDB = yes ]; then
 
     build_ncurses $triplet
-
     build_gmp $triplet
+    build_mpfr $triplet
+
+    la_expand_libs "$SYSROOTDIR/usr/lib/libgmp.la"
+    la_expand_libs "$SYSROOTDIR/usr/lib/libmpfr.la"
 
     build_dir_init native_gdb
 
@@ -451,10 +454,11 @@ if [ $DO_NATIVE_GDB = yes ]; then
     # C builds.
     config_path=$(calcConfigPath "${ARC_GNU}")/gdb
     configure_for_arc "$config_path" $triplet \
-	--with-libgmp-type=static \
-	--with-libgmp-prefix=$SYSROOTDIR/usr \
+	--with-libgmp=$SYSROOTDIR/usr \
+	--with-libmpfr=$SYSROOTDIR/usr \
 	--disable-build-with-cxx \
 	--disable-gas --disable-ld --disable-binutils
+
     make_target building
 
     # See comment for stripprog_opt for an explanation why this is needed.
@@ -462,6 +466,9 @@ if [ $DO_NATIVE_GDB = yes ]; then
     make_target_ordered installing install-strip-gdb \
     install-strip-gdbserver DESTDIR=$SYSROOTDIR \
 	STRIPPROG=${triplet}-strip
+
+    la_restore_libs "$SYSROOTDIR/usr/lib/libgmp.la"
+    la_restore_libs "$SYSROOTDIR/usr/lib/libmpfr.la"
 else
     # If native GDB has been disabled, then simple gdbserver still will be
     # built. It doesn't need ncurses.

--- a/build-uclibc.sh
+++ b/build-uclibc.sh
@@ -612,8 +612,11 @@ echo "  finished creating symlinks"
 if [ $DO_NATIVE_GDB = yes ]; then
 
     build_ncurses $triplet
-
     build_gmp $triplet
+    build_mpfr $triplet
+
+    la_expand_libs "$SYSROOTDIR/usr/lib/libgmp.la"
+    la_expand_libs "$SYSROOTDIR/usr/lib/libmpfr.la"
 
     build_dir_init native_gdb
 
@@ -626,10 +629,11 @@ if [ $DO_NATIVE_GDB = yes ]; then
     # C builds.
     config_path=$(calcConfigPath "${ARC_GNU}")/gdb
     configure_for_arc "$config_path" $triplet \
-	--with-libgmp-type=static \
-	--with-libgmp-prefix=$SYSROOTDIR/usr \
+	--with-libgmp=$SYSROOTDIR/usr \
+	--with-libmpfr=$SYSROOTDIR/usr \
 	--disable-build-with-cxx \
 	--disable-gas --disable-ld --disable-binutils
+
     make_target building
 
     # See comment for stripprog_opt for an explanation why this is needed.
@@ -637,6 +641,9 @@ if [ $DO_NATIVE_GDB = yes ]; then
     make_target_ordered installing install-strip-gdb \
     install-strip-gdbserver DESTDIR=$SYSROOTDIR \
 	STRIPPROG=${triplet}-strip
+
+    la_restore_libs "$SYSROOTDIR/usr/lib/libgmp.la"
+    la_restore_libs "$SYSROOTDIR/usr/lib/libmpfr.la"
 else
     # If native GDB has been disabled, then simple gdbserver still will be
     # built. It doesn't need ncurses.

--- a/doc/baremetal/em-starter-kit.rst
+++ b/doc/baremetal/em-starter-kit.rst
@@ -6,44 +6,64 @@
 Using GNU Toolchain to Debug Applications on EM Starter Kit
 ===========================================================
 
+To learn how to build and debug application using Eclipse IDE, please use
+:doc:`../ide/index` manual.
+
+You can find all necessary information about configuring the board and
+connecting to UART in a User Guide which is published in
+`ARC EM Starter Kit section <https://github.com/foss-for-synopsys-dwc-arc-processors/ARC-Development-Systems-Forum/wiki/ARC-Development-Systems-Forum-Wiki-Home#arc-em-starter-kit-1>`_
+on ARC Development Systems Forum.
+
 Prerequisites
 -------------
 
-Toolchain for Linux and Windows hosts can be downloaded from the `GNU Toolchain
-Releases page
-<https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases>`_.
-For Linux hosts there is a choice between complete tarballs that include
-toolchain, IDE and OpenOCD (like installer for Windows), and tarballs that
-include toolchain only.
+A toolchain for Linux and Windows hosts can be downloaded from the `GNU Toolchain
+Releases page <https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases>`_.
+OpenOCD for debugging applications on hardware boards is shipped with IDE bundle only.
+OpenOCD binary (``openocd`` for Linux and ``openocd.exe`` for Windows) resides in ``bin`` directory of IDE.
 
-In order to use OpenOCD on Windows it is required to install appropriate WinUSB drivers,
-see :doc:`../ide/how-to-use-openocd-on-windows` for details.
+Download and install Digilent Adept `runtime and utilities <https://digilent.com/shop/software/digilent-adept/download>`_
+to be able to work with EM Starter Kit on Linux. In order to use OpenOCD on Windows it is required to install
+appropriate WinUSB drivers, see :doc:`../ide/how-to-use-openocd-on-windows` for details.
 
 
-Building an application
------------------------
+Building a Simple Application
+-----------------------------
 
-To learn how to build and debug application with Eclipse IDE, please use
-:doc:`../ide/index` manual.
+Consider this simple application (assume that it's saved in ``main.c``):
 
-Different core templates in EM Starter Kit use different memory maps, so
-different memory map files are required to compile applications that work
-properly on those configurations. This "toolchain" repository includes memory
-maps for all supported EM Starter Kit versions and configurations. They can be
-found at
-https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/tree/arc-staging/extras/dev_systems
-Memory map files in that directory have ``.x`` extension and file to be used
-should be renamed to ``memory.x``, because ``arcv2elfx`` linker emulation
-doesn't support ability to override that file name. Please refer to
-:doc:`linker` for more details about ``memory.x`` files.
+.. code-block:: c
 
-For example for EM Starter Kit v2.3 EM7D to build an application::
+  int main()
+  {
+      return 0;
+  }
 
-    $ cp -a toolchain/extras/dev_systems/sk2.3_em7d.x memory.x
-    $ arc-elf32-gcc -Wl,-marcv2elfx --specs=nosys.specs -mcpu=em4_dmips -O2 -g \
-         test.c -o test.elf
+Different core templates in EM Starter Kit use different memory maps.
+It means that you need to use a special memory map file with ``.x`` extension
+to be able to compile and run your application on EM Starter Kit.
 
-.. table:: List of compiler flags corresponding to particular CPUs
+In first, clone `toolchain <https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain>`_
+repository and look into ``extras/dev_systems`` directory. This directory contains
+memory map files for different boards and cores. For example, ``sk2.3_em7d.x``
+is a memory map file for EM7D core of EM Starter Kit 2.3. You need to put that memory map
+file to the current directory, rename it to ``memory.x`` and use ``-Wl,-marcv2elfx``
+option while compiling your application. Please refer to :doc:`linker` for more details
+about ``memory.x`` files.
+
+That is how we compile the application for EM7D core of EM Starter Kit 2.3::
+
+  cp -a toolchain/extras/dev_systems/sk2.3_em7d.x memory.x
+  arc-elf32-gcc -g -Wl,-marcv2elfx -specs=nosys.specs -mcpu=em4_dmips main.c -o main.elf
+
+We use ``libnosys`` (``--specs=nosys.specs``) her to force standard IO functions
+to do nothing - they will set ``errno = ENOSYS`` and return -1 in most cases.
+
+You need to use correct ``-mcpu`` and other additional options for building your
+application for particular board and core. You can find all necessary options
+for any EM Starter Kit configuration in this table:
+
+.. table::
 
    +------+--------+------------------------------------------------------------+
    |EM SK |  CPU   |  Flags                                                     |
@@ -78,41 +98,43 @@ For example for EM Starter Kit v2.3 EM7D to build an application::
    |      | EM11D  | -mcpu=em4_fpuda -mfpu=fpuda_all                            |
    +------+--------+------------------------------------------------------------+
 
+Building an Application With Support of UART
+--------------------------------------------
 
-C library for GNU Toolchain for ARC provides basic support for UART module of EM
-Starter Kit, which allows to use standard C function for input and output:
-``printf()``, ``scanf()``, etc. Memory map files are also provided for processor
-configurations of EM Starter Kit. Both of those features are available via
-special "specs" files: ``emsk_em9d.specs`` and ``emsk_em11d.specs`` (there is no
-separate file for EM7D of EM Starter Kit, it is identical to EM9D). Usage
-example is following::
+Consider this application (assume that it's saved in ``hello.c``):
 
-    $ cat hello_world.c
-    #include <stdio.h>
-    int main() {
-        printf("hello world\n");
-        return 0;
-    }
+.. code-block:: c
 
-    $ arc-elf32-gcc --specs=emsk_em9d.specs -mcpu=em4_dmips hello_world.c
+  #include<stdio.h>
 
-Note that it is still required to specify valid ``-mcpu`` option value - it is
-not set by the specs file.
+  int main()
+  {
+      printf("Hello, World!\n");
+      return 0;
+  }
 
+You need to use ``emsk_em9d.specs`` (for EM7D or EM9D) or ``emsk_em11d.specs``
+(for EM11D) specs files instead of ``nosys.specs`` to enable support of UART.
+It allows using standard C function for input and output: ``printf()``, ``scanf()``,
+etc.
 
+That is how we compile the application for EM7D core of EM Starter Kit 2.3::
+
+  cp -a toolchain/extras/dev_systems/sk2.3_em7d.x memory.x
+  arc-elf32-gcc -g -Wl,-marcv2elfx -specs=emsk_em9d.specs -mcpu=em4_dmips main.c -o main.elf
 
 Running an application with OpenOCD
 -----------------------------------
 
+OpenOCD is used for connecting to development boards, running a GDB
+server and loading programs to the boards using GDB.
+
 Starting OpenOCD
 ^^^^^^^^^^^^^^^^
 
-Parameters of a particular target board are described in the OpenOCD
-configuration files. OpenOCD repository from Synopsys already includes several
-configuration files made specifically for Synopsys own development platforms:
-ARC EM Starter Kit and ARC SDP. Due to differences between different versions
-of ARC EM Starter Kit hardware, there are separate configuration files for
-different ARC EM Starter Kit versions:
+OpenOCD uses configuration files for describing different boards. OpenOCD
+is shipped with different configuration files for different EM Starter Kit
+versions:
 
 * ``snps_em_sk_v1.cfg`` - for ARC EM Starter Kit v1.x.
 * ``snps_em_sk_v2.1.cfg`` - for ARC EM Starter Kit versions 2.0 and 2.1.
@@ -121,66 +143,52 @@ different ARC EM Starter Kit versions:
 * ``snps_em_sk.cfg`` - this is a configuration for ARC EM Starter Kit 2.0 and
   2.1, preserved for compatibility.
 
-Following documentation would assume the usage of the latest ARC EM Starter Kit
-version 2.3 which is similar to 2.2.
+Assume that EM Starter Kit 2.3 is used. If you've downloaded IDE bundle for
+Linux then you can run OpenOCD this way (replace ``<ide>`` by a path to
+the directory of IDE bundle)::
 
-Start OpenOCD::
+  <ide>/bin/openocd -s <ide>/share/openocd/scripts -c 'gdb_port 49101' -f board/snps_em_sk_v2.3.cfg
 
-    # On Linux (for manually built OpenOCD):
-    $ openocd  -c 'gdb_port 49101' -f board/snps_em_sk_v2.3.cfg
+If you've built and installed OpenOCD manually then you can run OpenOCD this way::
 
-    # On Linux (for prebuilt OpenOCD from IDE package):
-    $ $ide_dir/bin/openocd -s $ide_dir/share/openocd/scripts \
-        -c 'gdb_port 49101' -f board/snps_em_sk_v2.3.cfg
+  openocd  -c 'gdb_port 49101' -f board/snps_em_sk_v2.2.cfg
 
-    @rem on Windows:
-    > openocd -s C:\arc_gnu\share\openocd\scripts -c "gdb_port 49101" ^
-      -f board\snps_em_sk_v2.3.cfg
+If you've downloaded and installed IDE bundle for Windows then you can run OpenOCD this way:
+
+.. code-block:: winbatch
+
+    openocd -s C:\arc_gnu\share\openocd\scripts -c "gdb_port 49101" -f board\snps_em_sk_v2.3.cfg
 
 OpenOCD will be waiting for GDB connections on TCP port specified as an
-argument to ``gdb_port`` command, in this example it is 49101. When
-``gdb_port`` command hasn't been specified, OpenOCD will use its default port,
-which is 3333, however this port might be already occupied by some other
-software. In our experience we had a case, where port 3333 has been occupied,
-however no error messages has been printed but OpenOCD and GDB wasn't printing
-anything useful as well, instead it was just printing some ambiguous error
-messages after timeout. In that case another application was occupying TCP port
-only on localhost address, thus OpenOCD was able to start listening on other IP
-addresses of system, and it was possible to connect GDB to it using that
-another IP address. Thus it is recommended to use TCP ports which are unlikely
-to be used by anything, like 49001-49150, which are not assigned to any
-application.
-
-OpenOCD can be closed by CTRL+C. It is also possible to start OpenOCD from Eclipse
-as an external application.
-
+argument to ``gdb_port`` command (49101 in our case). If ``gdb_port`` is not
+passed then the default port 3333 is used. It's recommended not to use a default
+port since it may be occupied by another application. OpenOCD can be closed by CTRL+C.
 
 Connecting GDB to OpenOCD
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Write a sample application:
+Write a sample application and save it to ``simple.c``:
 
 .. code-block:: c
 
-    /* simple.c */
-    int main(void) {
-        int a, b, c;
-        a = 1;
-        b = 2;
-        c = a + b;
-        return c;
-    }
+  int main()
+  {
+      int a = 1;
+      int b = 2;
+      int c = a + b;
+      return c;
+  }
 
+Build the application for EM7D core of EM Starter Kit 2.3::
 
-Compile it - refer to "Building application" section for details, creation of
-``memory.x`` is not shown in this example::
+  cp -a toolchain/extras/dev_systems/sk2.3_em7d.x memory.x
+  arc-elf32-gcc -g -Wl,-marcv2elfx -specs=nosys.specs -mcpu=em4_dmips main.c -o main.elf
 
-    $ arc-elf32-gcc -Wl,-marcv2elfx --specs=nosys.specs -mcpu=em4_dmips -O2 -g \
-        simple.c -o simple_sk2.3_em7d.elf
+Start OpenOCD as it described earlier and start GDB, connect to target and run it:
 
-Start GDB, connect to target and run it::
+.. code-block:: text
 
-    $ arc-elf32-gdb --quiet simple_sk2.1_em5d.elf
+    $ arc-elf32-gdb -quiet main.elf
     # Connect. Replace 3333 with port of your choice if you changed it when starting OpenOCD
     (gdb) target remote :3333
     # Increase timeout, because OpenOCD sometimes can be slow
@@ -199,24 +207,10 @@ Start GDB, connect to target and run it::
     # For example, check exit code of application
     (gdb) info reg r0
 
-Execution should stop at function ``exit``. Value of register ``r0`` should be
-``3``.
-
+Execution should stop at function ``exit``. Value of register ``r0`` should be ``3``.
 
 Known issues and limitations
 ----------------------------
-
-* Out of the box it is impossible to perform any input/output operations, like
-  printf, scanf, file IO, etc.
-
-    * When using an nSIM hostlink (GCC option ``--specs=nsim.specs``), calling
-      any of those function in application will result in a hang (unhandled
-      system call to be exact).
-    * When using libnosys (``--specs=nosys.specs``), standard IO functions will
-      simply do nothing - they will set ``errno = ENOSYS`` and return -1 at most.
-    * It is possible to use UART for text console I/O operations, but that is
-      not implemented by default in GNU toolchain. Consult EM Starter Kit
-      documentation and examples for details.
 
 * Bare metal applications has nowhere to exit, and default implementation of
   exit is an infinite loop. To catch exit from application you should set

--- a/doc/ide/getting-started-with-em-starter-kit.rst
+++ b/doc/ide/getting-started-with-em-starter-kit.rst
@@ -11,7 +11,7 @@ Creating Hello World project for ARC EM Starter Kit
    Creating a new C project
 
    The **C Project** window should have several ARC project types:
-   **ARC Cross ELF32 Target Application**, **ARC Cross ELF32 Target Static
+   **ARC Baremetal Application**, **ARC Cross ELF32 Target Static
    Library**, **AXS10x Projects** and **EM Starter Kit Projects**. Select
    **EM Starter Kit Projects**. This project type is available only if ARC EM
    toolchain compiler can be found either in ``PATH`` environment variable or

--- a/doc/ide/getting-started-with-nsim.rst
+++ b/doc/ide/getting-started-with-nsim.rst
@@ -18,7 +18,7 @@ Creating a C project
 
    Creating a new C project
 
-In **C Project** window select **Hello World C Project** under **ARC Cross ELF32 Target Application** project type.
+In **C Project** window select **Hello World C Project** under **ARC Baremetal Application** project type.
 On the right side of the window there is a list of available toolchains, select **GNU Toolchain for ARC EM**.
 If you do not see this toolchain in the list or this project type in the list of project types, make sure that ARC EM
 toolchain compiler is in the ``PATH`` environment variable or at ``../bin/`` directory relative to Eclipse executable.

--- a/doc/linux/kernel-build.rst
+++ b/doc/linux/kernel-build.rst
@@ -85,7 +85,7 @@ Contents of this file should be following::
     BR2_TOOLCHAIN_EXTERNAL=y
     BR2_TOOLCHAIN_EXTERNAL_CUSTOM=y
     BR2_TOOLCHAIN_EXTERNAL_DOWNLOAD=y
-    BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases/download/arc-2023.03-rc1/arc_gnu_2023.03-rc1_prebuilt_uclibc_le_archs_linux_install.tar.gz"
+    BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases/download/arc-2023.03-release/arc_gnu_2023.03_prebuilt_uclibc_le_archs_linux_install.tar.gz"
     BR2_TOOLCHAIN_EXTERNAL_LOCALE=y
     BR2_TOOLCHAIN_EXTERNAL_HAS_SSP=y
     BR2_TOOLCHAIN_EXTERNAL_CXX=y
@@ -219,7 +219,7 @@ differences::
     BR2_TOOLCHAIN_EXTERNAL_CUSTOM=y
     BR2_TOOLCHAIN_EXTERNAL_CUSTOM_GLIBC=y
     BR2_TOOLCHAIN_EXTERNAL_DOWNLOAD=y
-    BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases/download/arc-2023.03-rc1/arc_gnu_2023.03-rc1_prebuilt_glibc_le_archs_linux_install.tar.gz"
+    BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases/download/arc-2023.03-release/arc_gnu_2023.03_prebuilt_glibc_le_archs_linux_install.tar.gz"
     BR2_TOOLCHAIN_EXTERNAL_LOCALE=y
     BR2_TOOLCHAIN_EXTERNAL_HAS_SSP=y
     BR2_TOOLCHAIN_EXTERNAL_CXX=y
@@ -248,7 +248,7 @@ The resulting configuration file::
     BR2_TOOLCHAIN_EXTERNAL=y
     BR2_TOOLCHAIN_EXTERNAL_CUSTOM=y
     BR2_TOOLCHAIN_EXTERNAL_DOWNLOAD=y
-    BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases/download/arc-2023.03-rc1/arc_gnu_2023.03-rc1_prebuilt_uclibc_le_arc700_linux_install.tar.gz"
+    BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases/download/arc-2023.03-release/arc_gnu_2023.03_prebuilt_uclibc_le_arc700_linux_install.tar.gz"
     BR2_TOOLCHAIN_EXTERNAL_LOCALE=y
     BR2_TOOLCHAIN_EXTERNAL_HAS_SSP=y
     BR2_TOOLCHAIN_EXTERNAL_CXX=y
@@ -309,7 +309,7 @@ With those changes Buildroot defconfig for ARC HS VDK is::
     BR2_TOOLCHAIN_EXTERNAL=y
     BR2_TOOLCHAIN_EXTERNAL_CUSTOM=y
     BR2_TOOLCHAIN_EXTERNAL_DOWNLOAD=y
-    BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases/download/arc-2023.03-rc1/arc_gnu_2023.03-rc1_prebuilt_uclibc_le_archs_linux_install.tar.gz"
+    BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases/download/arc-2023.03-release/arc_gnu_2023.03_prebuilt_uclibc_le_archs_linux_install.tar.gz"
     BR2_TOOLCHAIN_EXTERNAL_LOCALE=y
     BR2_TOOLCHAIN_EXTERNAL_HAS_SSP=y
     BR2_TOOLCHAIN_EXTERNAL_CXX=y
@@ -400,7 +400,7 @@ defconfig is::
     BR2_TOOLCHAIN_EXTERNAL=y
     BR2_TOOLCHAIN_EXTERNAL_CUSTOM=y
     BR2_TOOLCHAIN_EXTERNAL_DOWNLOAD=y
-    BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases/download/arc-2023.03-rc1/arc_gnu_2023.03-rc1_prebuilt_uclibc_le_archs_linux_install.tar.gz"
+    BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases/download/arc-2023.03-release/arc_gnu_2023.03_prebuilt_uclibc_le_archs_linux_install.tar.gz"
     BR2_TOOLCHAIN_EXTERNAL_LOCALE=y
     BR2_TOOLCHAIN_EXTERNAL_HAS_SSP=y
     BR2_TOOLCHAIN_EXTERNAL_CXX=y
@@ -448,7 +448,7 @@ Contents of this file should be following::
     BR2_TOOLCHAIN_EXTERNAL=y
     BR2_TOOLCHAIN_EXTERNAL_CUSTOM=y
     BR2_TOOLCHAIN_EXTERNAL_DOWNLOAD=y
-    BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases/download/arc-2023.03-rc1/arc_gnu_2023.03-rc1_prebuilt_arc32_uclibc_linux_install.tar.gz"
+    BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases/download/arc-2023.03-release/arc_gnu_2023.03_prebuilt_arc32_uclibc_linux_install.tar.gz"
     BR2_TOOLCHAIN_EXTERNAL_HEADERS_5_16=y
     BR2_TOOLCHAIN_EXTERNAL_LOCALE=y
     BR2_TOOLCHAIN_EXTERNAL_HAS_SSP=y
@@ -539,7 +539,7 @@ Contents of this file should be following::
     BR2_TOOLCHAIN_EXTERNAL_CUSTOM=y
     BR2_TOOLCHAIN_EXTERNAL_CUSTOM_GLIBC=y
     BR2_TOOLCHAIN_EXTERNAL_DOWNLOAD=y
-    BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases/download/arc-2023.03-rc1/arc_gnu_2023.03-rc1_prebuilt_arc64_glibc_linux_install.tar.gz"
+    BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases/download/arc-2023.03-release/arc_gnu_2023.03_prebuilt_arc64_glibc_linux_install.tar.gz"
     BR2_TOOLCHAIN_EXTERNAL_HEADERS_5_16=y
     BR2_TOOLCHAIN_EXTERNAL_LOCALE=y
     BR2_TOOLCHAIN_EXTERNAL_HAS_SSP=y


### PR DESCRIPTION
Some commits were scuttered among other branches, so I gathered all of them and decided to push to `arc-release`. Also, I update `README.md`: add links to [the new documentation](https://foss-for-synopsys-dwc-arc-processors.github.io/documentation) site and [ARC-V Getting Started](https://foss-for-synopsys-dwc-arc-processors.github.io/arc-v-getting-started/index.html) page, removed EMSK section and added HSDK section instead.