### PR TITLE
Revert "build(deps): bump urllib3 from 1.26.18 to 1.26.19 in /doc"

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -26,5 +26,5 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 sphinxcontrib.applehelp==1.0.3
-urllib3==1.26.19
+urllib3==1.26.18
 zipp==3.11.0


### PR DESCRIPTION
Reverts foss-for-synopsys-dwc-arc-processors/toolchain#624