### PR TITLE
ci: Fix failed CI

### DIFF
--- a/.github/workflows/build-and-deploy-doc.yml
+++ b/.github/workflows/build-and-deploy-doc.yml
@@ -39,3 +39,10 @@ jobs:
         with:
           branch: gh-pages
           folder: doc/_build/html
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: html_doc
+          path: doc/_build/html
+          retention-days: 7

--- a/.github/workflows/build-and-deploy-doc.yml
+++ b/.github/workflows/build-and-deploy-doc.yml
@@ -19,14 +19,14 @@ on:
 jobs:
   doc-build-and-deploy:
     name: Build and deploy documentation
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
       - name: Build documentation
-        uses: ammaraskar/sphinx-action@0.4
+        uses: ammaraskar/sphinx-action@8.0.2
         with:
           docs-folder: doc
 

--- a/.github/workflows/build-and-deploy-doc.yml
+++ b/.github/workflows/build-and-deploy-doc.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build documentation
         uses: ammaraskar/sphinx-action@8.0.2

--- a/.github/workflows/build-and-deploy-doc.yml
+++ b/.github/workflows/build-and-deploy-doc.yml
@@ -4,10 +4,12 @@ on:
   push:
     paths:
       - doc/**
+      - .github/workflows/**
 
   pull_request:
     paths:
       - doc/**
+      - .github/workflows/**
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/build-and-deploy-doc.yml
+++ b/.github/workflows/build-and-deploy-doc.yml
@@ -1,4 +1,5 @@
-name: "Build and deploy doumentation"
+name: "Build and deploy documentation"
+
 on:
   push:
     paths:

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -3,8 +3,12 @@ name: "Toolchain CI"
 on:
   push:
     branches: [arc-releases]
+    paths:
+      - dejagnu/**
   pull_request:
     branches: [arc-releases]
+    paths:
+      - dejagnu/**
 
 jobs:
   tclint:

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -5,10 +5,12 @@ on:
     branches: [arc-releases]
     paths:
       - dejagnu/**
+      - .github/workflows/**
   pull_request:
     branches: [arc-releases]
     paths:
       - dejagnu/**
+      - .github/workflows/**
 
 jobs:
   tclint:

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   tclint:
     name: Lint a set of Expect scripts for dejagnu
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/dejagnu/nsim-extra.exp
+++ b/dejagnu/nsim-extra.exp
@@ -11,7 +11,7 @@
 # more details.
 
 # You should have received a copy of the GNU General Public License along
-# with this program.  If not, see <http://www.gnu.org/licenses/>.          
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
This PR obtains few updates which are related to CI.

Now we don't have a working pipeline in the default branch because:
- Sphinx action is obsolete;
- Github [changed ](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/) the default node;
- tclint: dejagnu/nsim-extra.exp:14:75: line has trailing whitespace [style:trailing-whitespace].