### PR TITLE
CI: Fix TCL linter job

### DIFF
--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install tclint
+          pip install tclint==0.5.0
 
       - name: Lint scripts
         run: |

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -26,5 +26,4 @@ jobs:
 
       - name: Lint scripts
         run: |
-          tclint $(find dejagnu/ \( -name "arc*.exp" -o -name "nsim*.exp" \)) \
-            --show-categories
+          tclint $(find dejagnu/ \( -name "arc*.exp" -o -name "nsim*.exp" \))


### PR DESCRIPTION
This PR sets `tclint` package version explicitly and removes unavailable `--show-categories` option in the latest package (details in https://github.com/nmoroze/tclint/releases/tag/v0.5.0).