### PR TITLE
arcv: Remove hardcoded ABI and ARCH flags.

### DIFF
--- a/dejagnu/arc-common.exp
+++ b/dejagnu/arc-common.exp
@@ -57,7 +57,6 @@ proc arc_get_cflags {} {
                 lappend cflags --specs=hl.specs
             } elseif {[board_info $board arc,hostlink] == "semihost"} {
                 lappend cflags --specs=semihost.specs --specs=arcv.specs \
-                    -mabi=ilp32 -march=rv32im_zba_zbb_zbs_zca_zcb_zcmp_zicsr \
                     -T arcv.ld
             } else {
                 lappend cflags --specs=nosys.specs

--- a/dejagnu/baseboards/arc-sim-nsimdrv.exp
+++ b/dejagnu/baseboards/arc-sim-nsimdrv.exp
@@ -216,6 +216,10 @@ if {[check_target_arc64_64]} {
         -p nsim_isa_core=3 \
         -on nsim_isa_sat
 } elseif {[check_target_arcv]} {
+    # Not used.
+    # The ARCV nSIM configuration is done through a wrapper.
+    # The wrapper/simulator name is defined by "setup_sim riscv" which will be
+    # the target alias name with "-run" suffix. (e.g., riscv64-unknown-elf-run)
     set ext \
         "-all.i.zicsr.zifencei.zihintpause.b.zca.zcb.zcmp.zcmt.a.m.zbb.zba.zbs"
     lappend nsim_flags \
@@ -292,7 +296,11 @@ if {[info exists env(ARC_NSIM_OPTS) ]} {
 }
 
 # Setup nSIM.
-set_board_info sim "$nsim_bin [join $nsim_flags]"
+if {[check_target_arcv]} {
+    setup_sim riscv
+} else {
+    set_board_info sim "$nsim_bin [join $nsim_flags]"
+}
 # is_simulator should be set already by 'load_generic_config "sim"'. Do it here
 # to be safe.
 set_board_info is_simulator 1


### PR DESCRIPTION
By removing the hardcoded `-mabi=ilp32` and
`-march=rv32im_zba_zbb_zbs_zca_zcb_zcmp_zicsr` options from the semihost
compiler flags, the compiler will now use its default ABI and
architecture settings unless specified elsewhere. This resolves the
problem where these hardcoded values were overriding the specific ABI
and architecture options required by certain tests.

Modified the nSIM setup logic to call setup_sim riscv when targeting
ARCV. It returns a simulator named with the target alias and a "-run"
suffix (for example, riscv64-unknown-elf-run), which can serve as a
wrapper for the simulator.

For non-ARCv targets, retain the previous behavior of setting the sim
board info directly.


