### PR TITLE
arcv: Fix GCC flags for picolibc target.

### DIFF
--- a/dejagnu/arc-common.exp
+++ b/dejagnu/arc-common.exp
@@ -56,8 +56,14 @@ proc arc_get_cflags {} {
             } elseif {[board_info $board arc,hostlink] == "metaware"} {
                 lappend cflags --specs=hl.specs
             } elseif {[board_info $board arc,hostlink] == "semihost"} {
-                lappend cflags --specs=semihost.specs --specs=arcv.specs \
-                    -T arcv.ld
+                # Special case for picolibc
+                if {[istarget "riscv*-snps-elf-picolibc"]} {
+                    lappend cflags --specs=picolibcpp.specs --crt0=semihost \
+                        --oslib=semihost
+                } else {
+                    lappend cflags --specs=semihost.specs --specs=arcv.specs \
+                        -T arcv.ld
+               }
             } else {
                 lappend cflags --specs=nosys.specs
             }


### PR DESCRIPTION
When picolibc is used, appends the correct flags
(--specs=picolibcpp.specs --crt0=semihost --oslib=semihost) to GCC instead of the default semihost flags.